### PR TITLE
Add Linear Regression Representation Notebook

### DIFF
--- a/01_Linear_Regression_Representation.ipynb
+++ b/01_Linear_Regression_Representation.ipynb
@@ -1,0 +1,484 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Import dependencies"
+      ],
+      "metadata": {
+        "id": "3BlJN-gOT8nI"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import urllib.request\n",
+        "\n",
+        "base_url = 'https://raw.githubusercontent.com/bryancheng14/Supervised-Machine-Learning-Regression-and-Classification/refs/heads/Linear-Regression-Representation/'\n",
+        "\n",
+        "files = ['deeplearning.mplstyle']\n",
+        "\n",
+        "for f in files:\n",
+        "    urllib.request.urlretrieve(base_url + f, \"/tmp/\" + f)\n"
+      ],
+      "metadata": {
+        "id": "OoVqz3xISIxj"
+      },
+      "execution_count": 1,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import numpy as np\n",
+        "import matplotlib.pyplot as plt\n",
+        "plt.style.use('/tmp/deeplearning.mplstyle')"
+      ],
+      "metadata": {
+        "id": "bOh5H7tLQH6d"
+      },
+      "execution_count": 2,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Problem Statement"
+      ],
+      "metadata": {
+        "id": "kUT4ar3HUZQq"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "prediction of housing price with 2 data points of housing data\n",
+        "| Size (1000 sqft)| Price ($m) |\n",
+        "|-----------------|------------|\n",
+        "| 1.0             | 300        |\n",
+        "| 2.0             | 500        |"
+      ],
+      "metadata": {
+        "id": "KOs1W1_3Ubou"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Creating dataset"
+      ],
+      "metadata": {
+        "id": "paawdruuUVxt"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "x_train = np.array([1.0, 2.0])\n",
+        "y_train = np.array([300.0, 500.0])\n",
+        "print(f'x_train = {x_train}')\n",
+        "print(f'y_train = {y_train}')"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "go1XvVfmTme9",
+        "outputId": "42163a7b-d2b1-4b0d-99f0-cdca98bbc3f1"
+      },
+      "execution_count": 3,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "x_train = [1. 2.]\n",
+            "y_train = [300. 500.]\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Number of training examples `m`"
+      ],
+      "metadata": {
+        "id": "FdTf6I_bWOTV"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "print(f'x_train.shape: {x_train.shape}')\n",
+        "m = x_train.shape[0]\n",
+        "print(f'Number of training examples is: {m}')"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "VRMV0JCDWNqy",
+        "outputId": "bf137fcf-8908-489a-df58-c32f862a9f20"
+      },
+      "execution_count": 4,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "x_train.shape: (2,)\n",
+            "Number of training examples is: 2\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "m = len(x_train)\n",
+        "print(f'Number of training examples is: {m}')"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "fjTf4HjlWu8Z",
+        "outputId": "509abd90-a9ee-4c7c-fe6e-2b74f811e65e"
+      },
+      "execution_count": 5,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Number of training examples is: 2\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Training example pairs $x^{i}$ and $y^{i}$"
+      ],
+      "metadata": {
+        "id": "SGhqkuFbW1nm"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "i = 0\n",
+        "x_i = x_train[i]\n",
+        "y_i = y_train[i]\n",
+        "print(f'(x^({i}), y^({i})) = ({x_i}, {y_i})')"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "yku252M9XOsh",
+        "outputId": "2043b365-2bde-4294-9836-44e295cdb926"
+      },
+      "execution_count": 6,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "(x^(0), y^(0)) = (1.0, 300.0)\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Plotting datapoints"
+      ],
+      "metadata": {
+        "id": "9GuRKRFMXh1w"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "plt.scatter(x_train, y_train, marker='x', c='r')\n",
+        "plt.title('Housing Prices')\n",
+        "plt.ylabel('Price (in 1000s of dollars)')\n",
+        "plt.xlabel('Size (1000 sqft)')\n",
+        "plt.show()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 460
+        },
+        "id": "77i8MY6kXkuT",
+        "outputId": "735972ee-1e5d-4709-c5d5-d06f105c35e4"
+      },
+      "execution_count": 7,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 640x480 with 1 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjAAAAG7CAYAAADdbq/pAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAO7hJREFUeJzt3XtcVVX+//H3QRRFBQS8oIKE10rxqEmMRuIlUzGv2cVSKc2yb1OOXbQmS820pka/2jhafo0sKzUNKrOaVBSnBvNGjjqZtyNo4pWLNxA8+/eHv86EXDoHORw3vp6PB484a6+994fzmGm/W2vtvS2GYRgCAAAwES9PFwAAAOAqAgwAADAdAgwAADAdAgwAADAdAgwAADAdAgwAADAdAgwAADAdAgwAADAdAgwAADAdAgxQxbz33nuyWCzat29fsW2FhYWyWCyaMmVK5Rf2/9lsNlksFr333nuVfu7w8HBZLBZZLBZ5eXkpNDRUd999t3766Sen94+Pj3dvkQCc4u3pAgBcX0JCQvSvf/1LzZs398j577zzTk2ZMkV2u1179uzRyy+/rJiYGO3atUsNGjQoc9/ExET5+flVUqUAykKAAVCpfHx8FB0d7bHzBwcHO87fpUsXRUREKDY2VkuWLNGECRNK3Cc/P18+Pj7q0KFDZZYKoAxMIQHQDz/8oF69eqlOnTqqXbu2evbsqR9++KFIn9jYWMXGxhbb98pplczMTI0aNUqNGzeWj4+PQkJC1L9/fx0/flxSyVNI8fHxatq0qbZv366YmBj5+vqqZcuWWrBgQbHzrVmzRh06dFDNmjXVokUL/d///Z/i4+MVHh5err+9c+fOkuSYcvu1ln/961/q0qWLatWqpeeee67Ev1WSDh48qBEjRqhRo0by8fFRRESEnnrqqSJ9NmzYoJ49e6pu3bqqXbu27rzzTu3cubNIn2+++UZdunSRv7+/6tSpo9atW2vatGnl+puA6wEjMEAVdenSJRUWFhZru9KOHTvUrVs33XTTTY71M6+99pq6deum1NRUtW/f3qXzjhgxQocOHdIbb7yh0NBQHTt2TGvXrtX58+fL3C83N1fDhw/X+PHj9dJLLykhIUHjxo1T69at1b17d0nS7t27FRcXp6ioKC1dulQXL17UK6+8opycHHl5le+/xw4ePChJCggIcLTl5OTovvvu0zPPPKMZM2aoVq1ape4bFRUlX19fTZs2TS1btlR6err+8Y9/OPp8+eWXGjhwoOLi4rRkyRJJ0uuvv66YmBjt2LFDoaGhOnDggAYMGKC7775bL730kmrUqKG9e/fqwIED5fqbgOuCAaBKSUhIMCSV+fPyyy87+g8dOtTw9/c3srKyHG05OTlGvXr1jMGDBzvaunXrZnTr1q3Y+Zo1a2aMGjXK8bl27drGnDlzSq3v4MGDhiQjISHB0TZq1ChDkrFu3TpHW15enhEYGGg88sgjjrb777/fCA4ONs6dO+do++WXXwwfHx+jWbNmZX8x/7/W4cOHGwUFBUZ+fr7x73//2+jSpYvh5eVlbN26tUgtSUlJv/u3jhgxwqhdu7Zx5MiRUs/ZvHlzo0ePHkXacnJyjKCgIOOpp54yDMMwPvnkE0OSkZOT87t/A4DLGIEBqqjExEQ1bdq0SNulS5eKrT9JSUlR//79i4xA+Pn5acCAAfriiy9cPm/nzp31xhtvyDAM9ejRQ23btpXFYvnd/Xx9fR0jLdLltTKtWrVSenq6oy01NVX9+vWTr6+voy0kJERdunRxerTio48+0kcffeT4HB4erk8++UQdO3Z0tFWvXl39+/f/3WP94x//UP/+/dW4ceMSt+/du1f79+/XCy+8UGQ0zNfXV3/4wx+UkpIiSbJarapevbruu+8+Pfzww7r99tt/d0ExcL1jDQxQRbVt21a33HJLkZ9OnToV63f69GmFhIQUa2/UqJGysrJcPu+yZcs0YMAA/eUvf1FkZKSaNGmiadOmyW63l7lfvXr1irX5+PgoLy/P8fno0aMlXtgbNmzodH19+/bV5s2btW3bNmVmZurgwYMaMmRIkT7169dXtWrVfvdYp06dKhYSf+vXdT+jR49W9erVi/ysWrVKp06dkiS1aNFC33zzjex2u2M9TXR0tDZs2OD03wVcbxiBAa5zgYGByszMLNaemZlZJFTUrFlTubm5xfqdPn26yOcGDRpo3rx5mjdvnvbs2aPFixfr5ZdfVv369TVu3LirqjUkJMQRCn7r2LFjTh8jMDBQt9xyS5l9nBkxki7f0XTkyJFStwcFBUmSZs6cqV69ehXbXqNGDcfv3bt3V/fu3ZWfn6/vvvtOL730kuLi4mSz2RQcHOxUPcD1hBEY4DrXrVs3rV69WmfOnHG0nTlzRl988UWRu46aNWumn3/+WRcvXnS0paSkFNnvSq1bt9aMGTNUr169YnfdlEd0dLRWr15dZEHw0aNH9d133131scujd+/eWrVqlY4ePVri9tatWys8PFy7du0qNhp2yy23KDIystg+Pj4+6tGjh5577jmdO3fOscgYQFGMwADXucmTJ2vVqlXq2bOnJk6cKIvFotdff13nz5/XSy+95Oh333336Z133tHDDz+s+Ph4HTx4ULNmzZK/v7+jT05Ojnr16qUHHnhAbdq0UfXq1fXZZ58pKytLvXv3vupaX3zxRa1YsUJ33nmnnnnmGeXn5+uVV15Rw4YNy30X0tWYOnWqVq9erS5duuiFF15QixYtdOTIEX399ddasmSJLBaL5s2bp4EDB+rixYu65557FBwcrGPHjun7779XWFiYJkyYoAULFiglJUX9+vVTaGioTp48qZkzZ6px48Zq27Ztpf9dgBkwAgNc5yIjI7V+/Xr5+flp1KhRGjFihOrUqaMNGzYUuYW6e/fuWrBggTZt2qS77rpLCQkJWrJkSZHFvzVr1lTHjh21cOFC3X333Ro8eLD+9a9/6cMPP9TAgQOvutabbrpJX375pc6cOaN77rlHkyZN0hNPPKFOnToVCVKVJTw8XKmpqYqOjtbzzz+vvn376uWXXy6yTqdfv35KSUnRuXPnNGbMGN1555167rnnlJmZqT/84Q+SpPbt2+vcuXN6/vnn1bt3bz3xxBO64YYbtG7dulJv4QaudxbDMAxPFwEA5XX27Fm1aNFCcXFxWrRokafLAVBJmEICYCp//OMf1aVLFzVu3Fi//PKL5syZo6ysrGJPvwVQtRFgAJhKXl6eJk6cqGPHjqlGjRqKiorSmjVrSlwQC6DqYgoJAACYDot4AQCA6VS5KSS73V7siZ8Wi8XpB1MBAIDKZxiGrpwU8vLyKvURCVUywJw7d87TZQAAgKtUu3btUgMMU0gAAMB0CDAAAMB0CDAAAMB0qtwamJIW65Y1hwYAADyvpDWsZd2Ac10EmLJWMQMAgGtTWQGGqzoAADAdAgwAADAdAgwAADAdAgwAADAdAgwAADAdAgwAADAdAgwAADAdAgwAAHBOTo60dGnRtqVLL7dXMgIMAAD4fTk5Up8+0v33S3PnXm6bO/fy5z59Kj3EeDTAhIeHq3Xr1rJarbJarVq2bJkkae/everSpYtatWqlzp07a9euXY59ytoGAADc4Nfwkpp6+fNTT0ktWlz+p3S5vZJDjMdHYJYtW6a0tDSlpaXp3nvvlSQ9+uijGjt2rH7++WdNnDhR8fHxjv5lbQMAABXsyvDyq/37i36u5BDj8QBzpePHj2vLli168MEHJUlDhw5VRkaG9u3bV+Y2AADgBl99VTy8lCY19XL/SuDxADNy5Ei1a9dOo0eP1okTJ5SRkaGQkBB5e19+z6TFYlFYWJjS09PL3AYAANzgvvukOXOc6ztnzuX+lcCjASYlJUU7duzQtm3bFBwcrFGjRnmyHAAAUJInn5SaNy+7T/Pml/tVEo8GmLCwMElS9erVNX78eG3cuFGhoaE6evSoCgsLJUmGYSg9PV1hYWFlbgMAAG4yd27xNS9X2r//v3cnVQKPBZhz584pOzvb8fnjjz9Whw4d1KBBA3Xs2FFLliyRJK1cuVJNmzZVixYtytwGAADcYOnS/95t9Hueeqr4c2LcxGIYhlEpZ7rCgQMHNHToUF26dEmGYSgiIkJz5sxReHi49uzZo/j4eJ06dUp+fn5KSEhQu3btJKnMbZJkt9t15syZIueqW7euvLw8vtwHAADzKe0upJJER0tffy35+7t8Glev3x4LMO5CgAEAoIKVFGKaNy86rXQV4UVy/frNVR0AAJTN3/9yOImOvvx5zhxp377/3p10leGlPBiBAQAAzsnJufycl9/eKr10qdS371WHF6aQCDAAAJgOU0gAAKDKI8AAAADTIcAAAADTIcAAAADTIcAAAADTIcAAAADTIcAAAADTIcAAAADTIcAAAADTIcAAAADTIcAAAADTIcAAAADTIcAAAADTIcAAAADTIcAAAADTIcAAAADTIcAAAADTIcAAAADTIcAAAADTIcAAAADTIcAAAADTIcAAAADTIcAAAADTIcAAAADTIcAAAADTIcAAAADTIcAAAADTIcAAAADTIcAAAADTIcAAAADT8XiASUhIkMViUVJSkiTp1ltvldVqldVqVdu2bWWxWLRjxw5JUnx8vJo0aeLY/uyzz3qwcgAA4Cnenjy5zWbTwoULFR0d7WjbtGmT4/cVK1Zo6tSpioyMdLQ9++yzGj9+fGWWCQAArjEeG4Gx2+0aM2aM3nrrLfn4+JTYZ9GiRRo9enQlVwYAAK51Hgsws2bNUteuXdWpU6cSt2dkZGjDhg168MEHi7TPmTNHkZGR6t+/v9LS0iqhUgAAcK3xyBTSzp07tXLlSqWkpJTa57333lP//v0VHBzsaHv11VcVEhIiLy8vJSYmqm/fvtq7d6/q1KlTGWUDAIBrhEdGYDZu3CibzaaWLVsqPDxcqampGjt2rObPny9JMgxDCQkJxaaPmjRpIi+vyyUPHjxYfn5+2rNnT6XXDwAAPMsjAWbcuHE6evSobDabbDaboqOj9c4772jcuHGSpHXr1qmwsFB33HFHkf0OHz7s+D01NVWnTp1SixYtKrV2AADgeR69C6k0ixYt0kMPPeQYbflVfHy8jh07pmrVqqlWrVr65JNP5O/v76EqAQCAp1gMwzA8XURFstvtOnPmTJG2unXrFgtDAADg2uHq9ZurOgAAMB0CDAAAMB0CDAAAMB0CDAAAMB0CDAAAMB0CDAAAMB0CDAAAMB0CDAAAMB0CDAAAMB0CDAAAMB0CDAAAMB0CDAAAMB0CDAAAMB0CDAAAMB0CDAAAMB0CDAAAMB0CDAAAMB0CDAAAMB0CDAAAMB0CDAAAMB0CDAAAMB0CDAAAMB0CDAAAMB0CDAAAMB0CDAAAMB0CDAAAMB0CDAAAMB0CDAAAMB0CDAAAMB0CDAAAMB0CDAAAMB0CDAAAMB0CDAAAMB2PB5iEhARZLBYlJSVJkmJjY3XDDTfIarXKarVq9uzZjr7Hjx9Xnz591LJlS7Vt21YpKSkeqhoAAHiStydPbrPZtHDhQkVHRxdpnz17tgYNGlSs/6RJkxQdHa2vv/5amzdv1uDBg3Xw4EFVr169kioGAADXAo+NwNjtdo0ZM0ZvvfWWfHx8nNpn+fLleuyxxyRJnTt3VuPGjbVhwwZ3lgkAAK5BHgsws2bNUteuXdWpU6di2yZNmqR27drp3nvv1YEDByRJp06dUkFBgRo1auToFx4ervT09EqrGQAAXBtcnkKy2+366aefdPr0aQUGBqpNmzby8nItB+3cuVMrV64scQ3LBx98oNDQUBmGoXnz5ql///7avXu3q2UCAIAqzOnksW3bNj344IMKDAxU27Ztdfvtt6tt27aqV6+eHnjgAW3bts3pk27cuFE2m00tW7ZUeHi4UlNTNXbsWM2fP1+hoaGSJIvFoieeeEIHDhzQqVOnFBQUJG9vb2VmZjqOY7PZFBYW5sKfCwAAqgKnAsxDDz2ku+66S02aNFFiYqJOnDihixcv6sSJE/rss88UGhqqu+66Sw899JBTJx03bpyOHj0qm80mm82m6OhovfPOO3rkkUd07NgxR7+VK1eqYcOGCgoKkiQNGzZMCxYskCRt3rxZR44cUbdu3Vz9mwEAgMk5NYXUrl07vf3226pRo0aR9qCgIMXGxio2NlbTpk3TvHnzrqqY/Px8xcXFKT8/X15eXgoODtbnn3/u2P76669rxIgRatmypWrUqKElS5ZwBxIAANchi2EYhqeLqEh2u11nzpwp0la3bl2X1+kAAIDK4+r12+Wr+t69e3XixAlJ0rlz5zR58mRNnTpVeXl55SgXAADAdS4HmOHDh+vo0aOSpBdffFGJiYlKTEzU008/XeHFAQAAlMTlKaTAwECdPHlSXl5eCgsL0/r161WnTh116NBBR44ccVedTmMKCQAA83H1+u3yc2AMw5DFYtGBAwfk5eWliIgISVJubm45ygUAAHCdywGmffv2evXVV5Wenq7evXtLko4cOSI/P78KLw4AAKAkLgeYuXPn6vHHH5ePj4/ee+89SdKaNWt0xx13VHRtAAAAJXJpDUxhYaE+/fRTDRgwQDVr1nRnXeXGGhgAAMzH1eu3y4t469atW+wE1xICDAAA5uP258BERkZqz5495asOAACgAri8BmbYsGEaPHiwJkyYoPDw8CLJqEePHhVaHAAAQElcnkIqdS7KYtGlS5cqpKirwRQSAADm4/bnwNjt9vJVBgAAUEEYlgAAAKbj8giMJP3nP//RunXrdPz4cf12BmratGkVVhgAAEBpXA4wK1as0PDhw3XTTTdp9+7duummm7Rr1y7ddttt7qgPAACgGJenkKZPn663335baWlpql27ttLS0jRr1izFxMS4oz4AAIBiXL4Lyc/PT1lZWapWrZoCAgKUnZ2tixcvKiIiQocPH3ZXnU7jLiQAAMzH7Q+y8/X11cWLFyVJgYGBOnLkiAoLC5WTk1OOcgEAAFzncoDp3LmzvvnmG0lSr169NHz4cA0dOlQdO3as8OIAAABK4vIUUmZmpi5duqQmTZooOztbEydOVG5urqZPn67mzZu7q06nMYUEAID5uP1ljtc6AgwAAObjlifxrlu3zqmT8y4kAABQGZwagXFm9IJ3IQEAgPJyywgM7z8CAADXEoYlAACA6Tg1AvPSSy85dTDehQQAACqDUwFm48aNv9vHYrFcdTEAAADO4DZqAADgcW5/lcCvjh8/ri1btuj48ePlPQQAAEC5uBxgcnNzNXjwYDVq1EhRUVEKCQnR4MGDeRcSAACoNC4HmOeee05ZWVnatm2bcnNztXXrVuXk5GjixInuqA8AAKAYl9fAhIWFafPmzWrYsKGjLTMzU507d1ZGRkaFF+gq1sAAAGA+bl8Dc+HCBQUEBBRpCwgI0IULF1w9FAAAQLm4HGA6d+6syZMnO57Oa7fbNWXKFN1yyy3lKiAhIUEWi0VJSUmSpIceekitWrVS+/bt1bVrV23evNnRNz4+Xk2aNJHVapXVatWzzz5brnMCAABzc+o5ML81a9Ys9erVS4sXL1azZs2Unp4ub29vffvtty6f3GazaeHChYqOjna0DR48WAsXLpS3t7dWrVqlYcOGyWazObY/++yzGj9+vMvnAgAAVYfLAaZNmzb66aef9MUXX+jw4cMKDQ1VXFyc6tat69Jx7Ha7xowZo7feektPP/20o33AgAGO36Ojo3XkyBEVFhbK29vlUgEAQBVVrlRQp04d3X///Vd14lmzZqlr167q1KlTqX3mzJmjfv36FQkvc+bM0bvvvquwsDBNnz5dVqv1quoAAADm41SAcfYdR86+M2nnzp1auXKlUlJSSu2zZMkSLV++vEifV199VSEhIfLy8lJiYqL69u2rvXv3qk6dOk6dFwAAVA1O3UYdExNT5POmTZtUr149hYWFKSMjQ6dPn1Z0dHSZgeS35s+fr2nTpsnHx0fS5duw/fz8NHXqVI0bN07Lli3Tiy++qLVr1yosLKzU47Ru3VofffRRkVEcbqMGAMB8XL1+u/wcmBdeeEHe3t6aMmWKvLy8ZLfbNXXqVBUWFurVV18tV9GxsbEaP368Bg0apOXLl+vPf/6z1qxZo2bNmhXpd/jwYTVt2lSSlJqaqv79+2v//v3y9/d39CHAAABgPm4PMA0bNtThw4dVvXp1R9vFixcVGhqqY8eOlaPkogGmevXqatSokYKCghzb165dq6CgIPXq1UvHjh1TtWrVVKtWLc2YMUPdu3cvciwCDAAA5uPq9dvlRbxeXl46cOCAWrdu7Wg7ePCgLBaLq4dyWL9+veP3goKCUvutWbOm3OcAAABVh8sBZsSIEerbt6+eeeYZhYeHy2az6a9//atGjBjhjvoAAACKcTnAzJw5UwEBAfrf//1fx5qUhx9+mJc5AgCASuPyGphrHWtgAAAwH7e/zBEAAMDTCDAAAMB0CDAAAMB0nAowu3btcncdAAAATnMqwPzhD39w/N6uXTu3FQMAAOAMpwJMrVq1lJmZKUmy2WzurAcAAOB3OfUcmOHDhys8PFwNGjTQhQsXSn3BYnp6eoUWBwAAUBKnnwOTmpqqffv26ZFHHtGCBQtK7DNq1KgKLa48eA4MAADm47Z3IUVHRys6Olr79u27JoIKAAC4fpXrSbyGYWjz5s1KT09XWFiYOnfufFUvc6xIjMAAAGA+bn8b9dGjRzVgwABt27ZN9erVU1ZWljp27KjPPvtMjRs3Ll/VAAAALnB5WOJPf/qTIiIidOLECZ08eVInTpxQixYt9Kc//ckd9QEAABTj8hRSSEiI9uzZIz8/P0dbTk6OWrdu7bjV2pOYQgIAwHzc/jJHwzCKHczLy0tV7KXWAADgGuZygOnWrZsee+wx5ebmSro8+vL444+rW7duFV4cAABASVxexDt79mzFxcUpMDBQgYGBysrKUtu2bbVq1Sp31AcAAFBMuW6jttvt+uGHH5SRkaHQ0FBFRUVdM2tMWAMDAID5uHr9LleAuZYRYAAAMB+3L+IFAADwNAIMAAAwHQIMAAAwHQIMAAAwHZcDzLx585SWliZJ2rZtm0JDQ3XDDTdo69atFV0bAABAiVy+CykiIkKpqalq0KCB4uLi1KZNG9WpU0cpKSlKTk52V51O4y4kAADMx+23Ufv7+ysnJ0eFhYUKDg7WL7/8oho1aqhhw4Y6depU+SuvIAQYAADMx9Xrt8tP4vX19VVWVpZ27typNm3ayNfXVwUFBSooKChfxQAAAC5yOcAMHjxYvXr10tmzZ/Xoo49Kknbs2KFmzZpVeHEAAAAlcXkKqaCgQIsXL1aNGjX04IMPysvLS8nJyTp+/Ljuvfded9XpNKaQAAAwH14lQIABAMB03LoGZtu2bZo/f762b9+u3Nxc+fn5qUOHDho3bpw6duxY/qoBAABc4PSwRGJiom677TadOnVKQ4cO1YQJEzR06FCdPn1aMTExSkpKKlcBCQkJslgsjv2PHz+uPn36qGXLlmrbtq1SUlIcfcvaBgAArh9Oj8C8+OKLWrJkiYYMGVJsW2Jiol544QUNGjTIpZPbbDYtXLhQ0dHRjrZJkyYpOjpaX3/9tTZv3qzBgwfr4MGDql69epnbAADA9cPpERibzaaBAweWuO2uu+6SzWZz6cR2u11jxozRW2+9JR8fH0f78uXL9dhjj0mSOnfurMaNG2vDhg2/uw0AAFw/nA4wYWFh+uKLL0rc9uWXX7p8G/WsWbPUtWtXderUydF26tQpFRQUqFGjRo628PBwpaenl7kNAABcX5yeQnrllVd0//33q1+/foqKilJAQICys7O1efNmrV69Wh988IHTJ925c6dWrlzJGhYAAFAuTgeYu+++W6GhoXr77be1bNkyx11IVqtVycnJuvXWW50+6caNG2Wz2dSyZUtJUmZmpsaOHaupU6fK29tbmZmZjpEWm82msLAwBQUFlboNAABcX66J58DExsZq/PjxGjRokOLj4xUeHq4pU6Zo8+bNGjRokGw2m6pXr17mtl/xHBgAAMzH7e9COnz4sNLS0pSbmyt/f39ZrVY1adKkfNWW4PXXX9eIESPUsmVL1ahRQ0uWLHEElLK2AQCA64fTIzA5OTkaNWqUPv/8c9WoUcOxBqagoEADBgzQ4sWL5efn5+56fxcjMAAAmI+r12+nr+pPPPGEzp07p7S0NOXl5SkzM1N5eXnavn27zp8/ryeeeOLqKgcAAHCS0yMwgYGB2rdvnwIDA4ttO3nypFq2bKmsrKwKL9BVjMAAAGA+bhuBsdvtslgsJW6zWCy6BtYCAwCA64TTASYuLk733nuvdu7cWaR9586deuCBB9S/f/8KLw4AAKAkTgeYefPmqXr16oqMjJSvr69CQkLk6+ur9u3bq3r16vrb3/7mzjoBAAAcXH4OzKFDh5SWlqYzZ844HmR3LT1MjjUwAACYj6vX72viQXYViQADAID5uPVBdtu2bdP8+fO1fft2x6sEOnTooHHjxqljx47lrxoAAMAFTg9LJCYm6rbbbtOpU6c0dOhQTZgwQUOHDtXp06cVExOjpKQkN5YJAADwX05PId1888165ZVXNGTIkGLbEhMT9ec//1m7d++u8AJdxRQSAADm47Y1MLVr11Zubq6qVatWbFthYaH8/Px0/vz5cpRcsQgwAACYj9seZBcWFqYvvviixG1ffvmlmjVr5kKZAAAA5ef0It5XXnlF999/v/r166eoqCjHyxw3b96s1atX64MPPnBnnQAAAA5OB5i7775boaGhevvtt7Vs2TLHXUhWq1XJycm69dZb3VknAACAA8+BAQAAHue2NTAAAADXigoJMPn5+SXenQQAAOAOFTYCU8VmogAAwDXM6UW8t99+e6nbDMOQxWKpkIIAAAB+j9MBZtOmTRo7dqyCg4OLbSsoKND3339foYUBAACUxukAc/PNN6tPnz6Ki4srti0vL08zZsyo0MIAAABK4/QamLi4OJ08ebLEbd7e3ho1alSFFQUAAFAWngMDAAA8jufAAACAKo8AAwAATIcAAwAATIcAAwAATIcAAwAATMfp58D81oEDB7R169Ziq4UffvjhCikKAACgLC7fRr1gwQI98cQTCgwMVO3atf97IItFBw4cqPACXcVt1AAAmI+r12+XA0yzZs00e/ZsDRkypPxVuhEBBgAA83F7gAkICFB2dna5C3Q3AgwAAObj9gfZxcXFacOGDeWrDgAAoAK4vIi3fv36GjRokIYOHarGjRsX2TZt2jSnj9O7d29lZmbKy8tLdevW1dy5cxUWFqaePXs6+pw/f14HDhzQ8ePHFRgYqNjYWB06dEj+/v6SpFGjRulPf/qTq38CAAAwOZcDzI8//iir1ar9+/dr//79jnaLxeLScZYvX66AgABJUmJiouLj4/Xjjz8qLS3N0efNN9/Uhg0bFBgY6GibPXu2Bg0a5GrZAACgCnE5wCQnJ1fIiX8NL5KUk5NTYgBatGiRZs6cWSHnAwAAVYdHV7aOHDlSoaGhmjx5sj744IMi277//ntlZWWpf//+RdonTZqkdu3a6d57770mbtsGAACVz6m7kPr06aOvv/5akhQTE1PqdFFKSkq5ili8eLGWLVum1atXO9pGjx6toKAg/eUvf3G0ZWRkKDQ0VIZhaN68efr73/+u3bt3FzkWdyEBAGA+brmNeubMmXr++eclSVOnTi2138svv+xKrUXUqlVLhw8fVlBQkM6ePauQkBBt3rxZbdq0KXWfmjVr6siRIwoKCnK0EWAAADAfV6/fTq2B+TW8SFcXUn6VnZ2t8+fPO+5iSkpKUlBQkGOx7rJly9S+ffsi4aWwsFCnTp1Sw4YNJUkrV65Uw4YNi4QXAABwfSjXu5CuVk5OjoYNG6YLFy7Iy8tL9evX16pVqxxTU4sWLdIjjzxSZJ/8/HzFxcUpPz9fXl5eCg4O1ueff+6J8gEAgIc5NYVktVr1yiuvqH///iWufzEMQ59//rmmTJmi7du3u6VQZzGFBACA+bhlDcx3332nJ598UseOHVPPnj3Vtm1b+fv7KycnR7t27dLatWvVoEEDzZ07V127dq2Yv6ScCDAAAJiPW9+FlJycrE8//VRbtmzR6dOnFRgYqE6dOmnIkCHq0aPH1VVeQQgwAACYj9tf5nitI8AAAGA+bn+ZIwAAgKcRYAAAgOkQYAAAgOkQYAAAgOkQYAAAgOm4HGDsdrtmzpypli1byt/fX5L0zTffaOHChRVeHAAAQElcDjBTpkzR8uXLNXXqVMdTeVu0aKH58+dXeHEAAAAlcfk5MDfccINSUlIUGhqqwMBAnT59Wna7XcHBwTp9+rS76nQaz4EBAMB83P4cmDNnzqhp06ZF2i5duiRvb4+8FxIAAFyHXA4w7dq104oVK4q0ffbZZ+rQoUOFFQUAAFAWl4dNXnvtNfXq1UtJSUnKy8vTmDFjtGLFCn377bfuqA8AAKAYl0dgbr31Vm3ZskXBwcGKjY2V3W7XmjVr1LlzZ3fUBwAAUAwvcwQAAB7n9kW8b7zxhjZt2lSkLTU1VW+++aarhwIAACgXl0dgwsLCtGPHDgUEBDjasrKy1L59e6Wnp1d0fS5jBAYAAPNx+whMdnZ2kfAiSfXq1VNWVparhwIAACgXlwNMaGiotm7dWqRt69atatKkSYUVBQAAUBaXA8zo0aN1//33KzExUbt27VJiYqIeeOABjRkzxh31AQAAFOPyc2CeeuopnT59WqNGjdLZs2dVp04d/fGPf9SECRPcUR8AAEAxV3Ub9cmTJxUcHFyR9Vw1FvECAGA+bl/E+1vXWngBAADXB6emkG688Ub95z//kXR5Ea/FYimx37VwGzUAAKj6nAowkydPdvw+ffp0txUDAADgDKcCzPDhwyVJhYWFqlWrlgYOHCgfHx+3FgYAAFAalxfx1q1bt9gim2sJi3gBADAfty/ijYyM1J49e8pXHQAAQAVw+Tkww4YN0+DBgzVhwgSFh4cXSUY9evSo0OIAAABK4vIUUmlDORaLRZcuXaqQoq4GU0gAAJiPq9dvl0dg7HZ7+SoDAACoIC4FmJSUFG3dulVRUVHq2rWru2oCAAAok9PzKu+++65iY2M1Y8YMdevWTUuWLLnqk/fu3VuRkZGyWq2KiYnR9u3bJUnh4eFq3bq1rFarrFarli1b5thn79696tKli1q1aqXOnTtr165dV10HAAAwF6fXwERGRmrixIl64IEH9MEHH2ju3LnavHnzVZ08OztbAQEBkqTExERNmTJFP/74o8LDw5WUlCSr1Vpsnx49emjkyJGKj4/XihUr9PrrrxepgzUwAACYj9tuo05PT3c80G748OE6dOjQVZR52a/hRZJycnJKfUXBr44fP64tW7bowQcflCQNHTpUGRkZ2rdv31XXAgAAzMPpNTB2u90RMKpVq6bCwsIKKWDkyJFKTk6WJK1evbpIu2EYioqK0muvvab69esrIyNDISEh8va+XLbFYlFYWJjS09PVokWLCqkHAABc+5wOMPn5+XrppZccny9cuFDksyRNmzbN5QLef/99SdLixYs1ceJErV69WikpKQoLC1NBQYFefPFFjRo1qki4AQAA1zen18DExsaWOcVjsVi0bt26qyqmVq1aOnz4sIKCghxtR48eVatWrXTmzBkdP35cLVq00OnTp+Xt7S3DMBQSEqJ//vOfjhEY1sAAAGA+bnsOzPr166+qsCtlZ2fr/Pnzaty4sSQpKSlJQUFBqlmzZpHFvR9//LE6dOggSWrQoIE6duyoJUuWKD4+XitXrlTTpk2ZPgIA4Drj8oPsKkpOTo6GDRumCxcuyMvLS/Xr19eqVat07NgxDR06VJcuXZJhGIqIiHBMM0nS22+/rfj4eM2YMUN+fn5KSEjw1J8AAAA8xOVXCVzrmEICAMB83P42agAAAE8jwAAAANMhwAAAANMhwAAAANMhwAAAANMhwAAAANMhwAAAANMhwAAAANMhwAAAANMhwAAAANMhwAAAANMhwAAAANMhwAAAANMhwAAAANMhwAAAANMhwAAAANMhwAAAANMhwAAAANMhwAAAANMhwAAAANMhwAAAANMhwAAAANMhwAAAANMhwAAAANMhwAAAANMhwAAAANMhwAAAANMhwAAAANMhwAAAANMhwAAAANMhwAAAANMhwAAAANMhwAAAANPxWIDp3bu3IiMjZbVaFRMTo+3btysvL0+DBg1Sq1at1L59e91xxx3at2+fY5/Y2FjdcMMNslqtslqtmj17tqfKBwAAHuTtqRMvX75cAQEBkqTExETFx8dr06ZNGjt2rPr27SuLxaK//e1vGjNmjNavX+/Yb/bs2Ro0aJBHagYAANcGj43A/BpeJCknJ0cWi0U1a9ZUv379ZLFYJEnR0dGy2WyeKRAAAFyzPLoGZuTIkQoNDdXkyZP1wQcfFNs+Z84cDRw4sEjbpEmT1K5dO9177706cOBAZZUKAACuIRbDMAxPF7F48WItW7ZMq1evdrTNmDFDX3zxhdauXStfX19JUkZGhkJDQ2UYhubNm6e///3v2r17d5Fj2e12nTlzpkhb3bp15eXFemUAAK5Vrl6/r4kAI0m1atXS4cOHFRQUpDfffFNLly7VmjVrikw1XalmzZo6cuSIgoKCHG0EGAAAzMfV67dHrurZ2dn65ZdfHJ+TkpIUFBSkwMBAzZo1Sx9//LG+/fbbIuGlsLBQx44dc3xeuXKlGjZsWCS8AACA64NH7kLKycnRsGHDdOHCBXl5eal+/fpatWqVjhw5oqeffloRERHq3r27JMnHx0ebNm1Sfn6+4uLilJ+fLy8vLwUHB+vzzz/3RPkAAMDDrpkppIrCFBIAAOZjiikkAACAq0GAAQAApkOAAQAApkOAAQAApkOAAQAApkOAAQAApkOAAQAApkOAAQAApkOAAQAApkOAAQAApkOAAQAApkOAAQAApkOAAQAApkOAAQAApkOAAQAApkOAAQAApkOAAQAApkOAAQAApkOAAQAApkOAAQAApkOAAQAApkOAAQAApkOAAQAApkOAAQAApkOAAQAApkOAAQAApkOAAQAApkOAAQAApkOAAQAApkOAAQAApkOAAQAApkOAcVZOjrR0adG2pUsvtwMAgEpFgHFGTo7Up490//3S3LmX2+bOvfy5Tx9CDAAAlcyjAaZ3796KjIyU1WpVTEyMtm/fLknau3evunTpolatWqlz587atWuXY5+ytrnFr+ElNfXy56eeklq0uPxP6XI7IQYAgErl0QCzfPly7dixQ2lpaZowYYLi4+MlSY8++qjGjh2rn3/+WRMnTnS0/962CndlePnV/v1FPxNiAACoVB4NMAEBAY7fc3JyZLFYdPz4cW3ZskUPPvigJGno0KHKyMjQvn37ytzmFl99VTy8lCY19XJ/AADgdt6eLmDkyJFKTk6WJK1evVoZGRkKCQmRt/fl0iwWi8LCwpSeni5/f/9St7Vo0aLii7vvPun48f9OF5VlzpzL/QEAgNt5fBHv+++/r4yMDE2fPl0TJ070dDnFPfmk1Lx52X2aN7/cDwAAVAqPB5hfjRo1SsnJyWratKmOHj2qwsJCSZJhGEpPT1dYWJhCQ0NL3eY2c+cWX/Nypf37/3t3EgAAcDuPBZjs7Gz98ssvjs9JSUkKCgpSgwYN1LFjRy1ZskSStHLlSjVt2lQtWrQoc5tbLF3q3PSRdLnflc+JAQAAbmExDMPwxIkPHTqkYcOG6cKFC/Ly8lL9+vX15ptvymq1as+ePYqPj9epU6fk5+enhIQEtWvXTpLK3CZJdrtdZ86cKXKuunXrysurHFmttLuQShIdLX39teTv7/p5AAC4zrl6/fZYgHGXCg0wUskhpnnzotNKhBcAAK6Kq9fva2YNzDXL3/9yOImOvvx5zhxp377L/5QILwAAeAAjMM7Kybn8nJff3iq9dKnUty/hBQCAq8QUkrsCDAAAcBumkAAAQJVHgAEAAKZDgAEAAKZDgAEAAKZDgAEAAKZDgAEAAKbj7ekCKlpJd4Xb7XYPVAIAAJxV0rW6rCe9XBcB5ty5cx6oBAAAXI2yAgxTSAAAwHQIMAAAwHQIMAAAwHSq5LuQrlwIZLFYZLFYPFQRAAD4PYZhFFvz4uXldf28zBEAAFR9TCEBAADTIcCU4sknn1R4eLgsFovS0tJK7bdo0SK1bNlSzZs31yOPPKKCgoLKK7IKcOZ7XrdunaKionTTTTfp5ptv1nPPPcezfVzk7P+epcvDuD169FBAQECl1FaVOPs9//vf/1ZsbKxuvPFG3Xjjjfr0008rr8gqwJnv2W63a8KECbrpppsUGRmp7t27a9++fZVbqMnl5eVp0KBBatWqldq3b6877rij1O9w1apVatOmjVq2bKkhQ4YoNzfX7fURYEpx991365///KeaNWtWap+DBw9q8uTJ2rhxo/bt26djx47pnXfeqcQqzc+Z77levXpaunSpdu/era1bt+r777/X+++/X4lVmp8z3/OvZs+erebNm1dCVVWPM9/z+fPnNXDgQE2fPl3/+c9/tHPnTsXExFRilebnzPf8+eef67vvvtOPP/6oHTt2qGfPnnrhhRcqscqqYezYsdqzZ49+/PFHDRw4UGPGjCnW5+zZsxo9erSSkpK0d+9eNW7cWK+88orbayPAlOL2229X06ZNy+yzYsUKDRgwQI0aNZLFYtFjjz2mjz/+uJIqrBqc+Z47dOigiIgISVLNmjVltVpls9kqobqqw5nvWZJ27dqlpKQkTZo0qRKqqnqc+Z4/+ugjRUdH67bbbpMkVatWTfXr16+M8qoMZ75ni8Wi/Px85eXlyTAM5ebmOvX/AfxXzZo11a9fP8dNMNHR0SX+u/err75Shw4d1KZNG0nS448/XinXwir3JN7KlJ6eXuS/AMLDw5Wenu7Biqq+zMxMrVixQqtWrfJ0KVVOQUGBHnnkES1atEjVqlXzdDlV1u7du+Xj46P+/fvr8OHDioyM1F//+ldCTAW76667lJycrEaNGqlu3bpq0qSJNmzY4OmyTG3OnDkaOHBgsfaSroVHjx5VYWGhvL3dFzMYgYFp5Obm6q677tJzzz2nW265xdPlVDlTp07VkCFDdOONN3q6lCqtsLBQa9as0dtvv63t27erSZMmGjdunKfLqnK2bNminTt36siRI/rll1/Us2dPPfbYY54uy7RmzJihffv2aebMmZ4uxYEAcxXCwsJ06NAhx2ebzaawsDAPVlR1nTlzRn369NHAgQM1YcIET5dTJW3YsEFvvfWWwsPDddtttyk3N1fh4eE6ceKEp0urUsLCwtS9e3c1adJEFotFDz74oFJTUz1dVpXz/vvvOxaje3l5adSoUUpOTvZ0Wab05ptv6tNPP9VXX30lX1/fYttLuhaGhIS4dfRFIsBclaFDh+rzzz9XZmamDMPQggULdN9993m6rCrn7Nmz6tOnj/r06aMXX3zR0+VUWRs3btShQ4dks9n0z3/+U35+frLZbExtVLB77rlHmzdvdtylsXr1arVv397DVVU9ERERWrdunS5evCjp8l0ybdu29XBV5jNr1ix9/PHH+vbbb0u9M7FPnz7atm2bfvrpJ0nS3//+98q5Fhoo0dixY40mTZoY1apVMxo0aGA0b97cMAzDGD16tPHZZ585+r3zzjtGRESEERERYTz88MPGxYsXPVWyKTnzPU+fPt3w9vY22rdv7/iZPn26J8s2HWf/9/yrgwcPGv7+/pVcpfk5+z2///77xs0332y0a9fO6NOnj5Genu6pkk3Jme85Ly/PGDNmjNGmTRujXbt2xh133GHs37/fk2WbTkZGhiHJiIiIcPy7NyoqyjAMw5g8ebIxf/58R9/PPvvMaN26tdG8eXNj4MCBRnZ2ttvr40m8AADAdJhCAgAApkOAAQAApkOAAQAApkOAAQAApkOAAQAApkOAAQAApkOAASDp8oPs6tSpo0uXLrntHB999JHi4uLcdvxrhc1mU0xMjPz8/NSlS5cS+5w7d07NmjXTzz//XMnVAVUDAQa4Thw8eFD333+/GjdurDp16qhx48bq16+fjh49KkmKiYnR2bNn3fYix7y8PD3zzDN69dVXHW1r165Vz549FRQUJIvFon379hXbLz09Xf3791fdunUVHBysJ554wvF01V/NmzdP4eHh8vX1VceOHZWSkuLyMSrSzJkzVa9ePWVnZ+v777/Xe++9V+xNyLVr19aECRP09NNPu60OoCojwADXiX79+qlu3brauXOnzp49q+3bt+vee++VxWKplPN//PHHatq0qaxWq6Otdu3aGjlypN5///0S97Hb7erfv78CAwN15MgRbd26VSkpKXr22WcdfT755BO98MILWrx4sbKzszV69Gj169dPGRkZTh+jou3fv1+RkZHy8ir7X7EjR47UmjVrGIUBysPtz/oF4HEnT540JBlbt24ttU9ycrIhySgoKDAMwzAaNmxo1K5d2/Hj7e1tdOvWzdH/yy+/NKKiooyAgACjRYsWxpw5c8qsIS4uznjxxRdL3Hbw4EFDkrF3794i7evXrze8vb2NEydOONqSkpIMX19f48KFC4ZhGEZsbKwxfvz4IvtZrVZj2rRpTh/jSmlpacbtt99u+Pv7GwEBAUbHjh2Nn376yTAMwygoKDCeffZZo2HDhkZwcLAxadIko2vXrsbLL79sGIZhREREGF5eXkb16tWN2rVrG1OmTDF8fHwMi8Xi+C6XLFniOFdMTIzx2muvlfndASiOERjgOhAUFKR27drp0UcfVUJCgnbs2CG73V7mPpmZmTp79qzOnj2r1NRU+fn56eGHH5YkJScna/jw4ZoxY4ZOnTqlxMREvfHGG/rwww9LPd6WLVtcfpleWlqaIiIiFBwc7Gjr3Lmzzp8/7xi1SEtLU1RUVJH9OnfurO3btzt9jCs9/vjj6tmzp06ePKkTJ05o0aJFjhfZ/eUvf9Hy5cu1bt06HT58WN7e3tq0aZNj3/379ysmJkbPPfeczp49q5dfflkLFixQ48aNHd/nAw884OgfGRmpzZs3u/S9AGAKCbhuJCcnq2/fvpo/f76ioqIUHBysZ555Rvn5+WXud+jQIfXp00fPP/+8Ro4cKUmaPXu2xo0bp549e8rLy0tt27bVY489poSEhFKPc/r0afn7+7tUc25ubrE34NarV8+xraw+v7f9t8e4Uo0aNZSenq5Dhw7J29tbVqtVDRs2lCQlJCTo6aef1k033SQfHx9NmTLFcbzy8Pf31+nTp8u9P3C9IsAA14mgoCBNmzZNP/zwg3JycvTuu+9q4cKFmjlzZqn7nDx5Unfeeafuu+8+PfPMM472vXv3as6cOQoICHD8vPbaa44FwSUJDAxUTk6OSzX7+fkpOzu7SFtWVpZjW1l9fm/7b49xpffee08Wi0U9evRQ06ZNNX78eJ09e1aSdPjwYd1www2OvtWqVVNYWJhLf9dv5eTkKDAwsNz7A9crAgxwHfLx8dGgQYPUq1cvbdu2rcQ+586dU1xcnKKiovTGG28U2daoUSNNmjRJ2dnZjp8zZ85o165dpZ6zU6dOZW4vidVq1cGDB3Xq1ClH25YtW+Tr66tWrVo5+lw5BbNlyxZ16NDB6WNcqVmzZlq4cKEOHTqk9evX69tvv3UEvaZNm8pmszn6Xrp0ybFguDRlLeb997//rVtuuaXM/QEUR4ABrgNZWVmaNGmSduzYofz8fF26dElr165VcnKybr/99mL9CwsLNXToUAUHB+vdd98tdqfSU089pbfeektr165VYWGhCgsLtXPnzmK3L//WkCFD9M033xRps9vtysvLc0xjXbx4UXl5eY5n0cTExKhNmzZ6+umndebMGaWnp+ull17S6NGjVbNmTUmX16u8++672rhxoy5evKj58+fr559/Vnx8vNPHuNJ7772nw4cPyzAM+fn5ydvbW97e3pKkUaNG6a9//at++ukn5efna9q0ab87BdSoUSOdPHmySIiSpOzsbP3www8aNGhQmfsDKIGnVxEDcL+zZ88ao0ePNlq1amXUqVPH8Pf3N26++WbjtddeM+x2u2EYRe9C+vWuoJo1axa5E6lPnz6OY3711VdGly5djHr16hn16tUzbr31VmPlypWl1nDhwgWjUaNGxvbt2x1tv57zyp+EhARHH5vNZvTr18+oXbu2ERgYaPzP//yPkZeXV+TYb731lhEWFmbUrFnT6NChg7F+/foi2505xm+NHDnSCAkJMXx9fY1GjRoZjz76qHHu3DnDMAzj4sWLxoQJE4wGDRqUeBeSYRhGt27djD//+c+OzwUFBcY999xjBAYGGv7+/saHH35oGIZhzJkzx4iLiyu1DgClsxiGYXgwPwG4jnz44Yf66KOP9OWXX3q6lAp12223qVevXpoyZYrT+5w7d04333yzvvnmG7Vu3dp9xQFVlLenCwBw/XjggQeK3EJ8Patdu3aRtTQAXMMaGAAAYDpMIQEAANNhBAYAAJgOAQYAAJgOAQYAAJgOAQYAAJgOAQYAAJgOAQYAAJgOAQYAAJgOAQYAAJgOAQYAAJjO/wPM7Ftx+YL+4AAAAABJRU5ErkJggg==\n"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Linear Regression Model\n",
+        "denoted as $f_{w,b}(x^i)=w \\times x^i+b$\n",
+        "\n",
+        "let $w = 100$ and $b = 100$"
+      ],
+      "metadata": {
+        "id": "MWwXLGDNXxQI"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "w = 100\n",
+        "b = 100\n",
+        "print(f'w: {w}')\n",
+        "print(f'b: {b}')"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "PkGxuwutZEDW",
+        "outputId": "96197e0c-9653-41b5-aa63-118049692c0a"
+      },
+      "execution_count": 8,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "w: 100\n",
+            "b: 100\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def compute_model_output(x, w, b):\n",
+        "  \"\"\"\n",
+        "  Computes the prediction of a linear model\n",
+        "  Args:\n",
+        "    x (ndarray (m,)): Data, m examples\n",
+        "    w,b (scalar)    : model parameters\n",
+        "  Returns\n",
+        "    f_wb (ndarray (m,)): model prediction\n",
+        "  \"\"\"\n",
+        "  m = x.shape[0]\n",
+        "  f_wb = np.zeros(m)\n",
+        "  for i in range(m):\n",
+        "      f_wb[i] = w * x[i] + b\n",
+        "\n",
+        "  return f_wb"
+      ],
+      "metadata": {
+        "id": "Hil8kNLpZsbH"
+      },
+      "execution_count": 9,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "tmp_f_wb = compute_model_output(x_train, w, b)\n",
+        "print(f'our predicted prices: {tmp_f_wb}')"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "7vahkHyPZ7Uw",
+        "outputId": "686cf34f-9aa5-47a3-8ac7-19f1409ba71c"
+      },
+      "execution_count": 10,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "our predicted prices: [200. 300.]\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "plt.plot(x_train, tmp_f_wb, c='b',label='Our Prediction')\n",
+        "plt.scatter(x_train, y_train, marker='x', c='r',label='Actual Values')\n",
+        "plt.title('Housing Prices')\n",
+        "plt.ylabel('Price (in 1000s of dollars)')\n",
+        "plt.xlabel('Size (1000 sqft)')\n",
+        "plt.legend()\n",
+        "plt.show()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 460
+        },
+        "id": "5u1o-LmsaHU6",
+        "outputId": "a6cc9663-a78c-40c9-9674-2d1a2a385f43"
+      },
+      "execution_count": 11,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 640x480 with 1 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjAAAAG7CAYAAADdbq/pAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAATyVJREFUeJzt3XlcVPX+P/DXDAjKvsmmICGIC+KAgkSyuFQq7raYe7lVP78t5lXrppl6LW+lmZlW1zQ1tW6mlZmlKaAlCgiamgvKCJqAsoOyOef3x1xmHFmcwTMMB17Px8NHcc6Zz7yZ7m1efd6fcz4yQRAEEBEREUmI3NQFEBERERmKAYaIiIgkhwGGiIiIJIcBhoiIiCSHAYaIiIgkhwGGiIiIJIcBhoiIiCSHAYaIiIgkhwGGiIiIJIcBhqiF2bRpE2QyGdLT02udq66uhkwmw+LFi5u+sP9RKpWQyWTYtGlTk7+3j48PZDIZZDIZ5HI5vLy88MQTT+DcuXN6v37q1KnGLZKI9GJu6gKIqHXx8PDA0aNH0blzZ5O8/+OPP47FixdDpVLh/PnzeOuttxAZGYkzZ87A1dW1wdfu2rULdnZ2TVQpETWEAYaImpSlpSXCw8NN9v4uLi6a94+IiICvry9iYmKwdetWzJkzp87XVFRUwNLSEsHBwU1ZKhE1gC0kIsLx48cxaNAg2NjYwNraGgMHDsTx48d1romJiUFMTEyt197bVsnOzsaUKVPg6ekJS0tLeHh4YNiwYcjNzQVQdwtp6tSp6NixI1JTUxEZGQkrKyv4+/tj/fr1td7vwIEDCA4ORtu2beHn54f//Oc/mDp1Knx8fBr1u4eGhgKApuVWU8vRo0cRERGBdu3aYd68eXX+rgCQkZGBSZMmwd3dHZaWlvD19cXLL7+sc018fDwGDhwIW1tbWFtb4/HHH8fp06d1rvnll18QEREBe3t72NjYICAgAEuWLGnU70TUGnAGhqiFunPnDqqrq2sdu9epU6cQHR2N7t27a9bPvPvuu4iOjkZiYiJ69epl0PtOmjQJV65cwXvvvQcvLy/k5OTgt99+w61btxp8XXFxMcaPH49XXnkFixYtwsaNG/HCCy8gICAA/fv3BwCcPXsWsbGxCAsLw44dO1BZWYmlS5eiqKgIcnnj/nssIyMDAODg4KA5VlRUhHHjxmHu3LlYvnw52rVrV+9rw8LCYGVlhSVLlsDf3x+ZmZn49ddfNdf89NNPGDlyJGJjY7F161YAwIoVKxAZGYlTp07By8sLly9fxogRI/DEE09g0aJFsLCwwMWLF3H58uVG/U5ErYJARC3Kxo0bBQAN/nnrrbc0148dO1awt7cXCgoKNMeKiooER0dHYfTo0Zpj0dHRQnR0dK3369SpkzBlyhTNz9bW1sLq1avrrS8jI0MAIGzcuFFzbMqUKQIA4eDBg5pj5eXlgpOTkzBjxgzNsWeeeUZwcXERysrKNMf+/vtvwdLSUujUqVPDH8z/ah0/frxQVVUlVFRUCH/++acQEREhyOVyISUlRaeW3bt33/d3nTRpkmBtbS1cu3at3vfs3LmzMGDAAJ1jRUVFgrOzs/Dyyy8LgiAI//3vfwUAQlFR0X1/ByJS4wwMUQu1a9cudOzYUefYnTt3aq0/SUhIwLBhw3RmIOzs7DBixAj8+OOPBr9vaGgo3nvvPQiCgAEDBiAwMBAymey+r7OystLMtADqtTJdunRBZmam5lhiYiKGDh0KKysrzTEPDw9EREToPVuxbds2bNu2TfOzj48P/vvf/yIkJERzrE2bNhg2bNh9x/r1118xbNgweHp61nn+4sWLuHTpEt544w2d2TArKys8/PDDSEhIAAAoFAq0adMG48aNw3PPPYeoqKj7Ligmau24BoaohQoMDESfPn10/vTu3bvWdfn5+fDw8Kh13N3dHQUFBQa/79dff40RI0bg3//+N4KCgtChQwcsWbIEKpWqwdc5OjrWOmZpaYny8nLNz9evX6/zi93NzU3v+oYMGYKkpCScOHEC2dnZyMjIwJgxY3Suad++PczMzO47Vl5eXq2QeLeadT/Tpk1DmzZtdP7s2bMHeXl5AAA/Pz/88ssvUKlUmvU04eHhiI+P1/v3ImptOAND1Mo5OTkhOzu71vHs7GydUNG2bVsUFxfXui4/P1/nZ1dXV6xduxZr167F+fPn8eWXX+Ktt95C+/bt8cILLzxQrR4eHppQcLecnBy9x3ByckKfPn0avEafGSNAfUfTtWvX6j3v7OwMAHjnnXcwaNCgWuctLCw0f9+/f3/0798fFRUV+P3337Fo0SLExsZCqVTCxcVFr3qIWhPOwBC1ctHR0di7dy9KSko0x0pKSvDjjz/q3HXUqVMnXLhwAZWVlZpjCQkJOq+7V0BAAJYvXw5HR8dad900Rnh4OPbu3auzIPj69ev4/fffH3jsxnjsscewZ88eXL9+vc7zAQEB8PHxwZkzZ2rNhvXp0wdBQUG1XmNpaYkBAwZg3rx5KCsr0ywyJiJdnIEhauUWLlyIPXv2YODAgZg/fz5kMhlWrFiBW7duYdGiRZrrxo0bh88++wzPPfccpk6dioyMDKxcuRL29vaaa4qKijBo0CBMmDABXbt2RZs2bfD999+joKAAjz322APX+uabb+Lbb7/F448/jrlz56KiogJLly6Fm5tbo+9CehBvv/029u7di4iICLzxxhvw8/PDtWvXsG/fPmzduhUymQxr167FyJEjUVlZiaeeegouLi7IycnBH3/8AW9vb8yZMwfr169HQkIChg4dCi8vL9y8eRPvvPMOPD09ERgY2OS/F5EUcAaGqJULCgpCXFwc7OzsMGXKFEyaNAk2NjaIj4/XuYW6f//+WL9+PY4dO4bhw4dj48aN2Lp1q87i37Zt2yIkJASff/45nnjiCYwePRpHjx7FV199hZEjRz5wrd27d8dPP/2EkpISPPXUU1iwYAFmz56N3r176wSppuLj44PExESEh4fj9ddfx5AhQ/DWW2/prNMZOnQoEhISUFZWhunTp+Pxxx/HvHnzkJ2djYcffhgA0KtXL5SVleH111/HY489htmzZ+Ohhx7CwYMH672Fm6i1kwmCIJi6CCKixiotLYWfnx9iY2OxYcMGU5dDRE2ELSQikpT/+7//Q0REBDw9PfH3339j9erVKCgoqPX0WyJq2RhgiEhSysvLMX/+fOTk5MDCwgJhYWE4cOBAnQtiiajlYguJiIiIJIeLeImIiEhyWlwLSaVS1Xrip0wm0/vBVERERNT0BEHAvU0huVxe7yMSWmSAKSsrM3UZRERE9ICsra3rDTBsIREREZHkMMAQERGR5DDAEBERkeS0uDUwdS3WbaiHRkRERKZX1xrWhm7AaRUBpqFVzERERNQ8NRRg+K1OREREksMAQ0RERJLT4lpI96NSqZCTk4Pq6mpTl0Iis7e3h52dnanLICKiJtDqAkxOTg5sbW1hY2Nj6lJIRIIg4ObNm8jNzYWrq6upyyEiIiNrdS2k6upqhpcWSCaToX379qioqDB1KURE1ARaXYAhIiIi6WOAaQYqKysxf/58+Pn5oVu3bujZsye+/PJL0cb38fFBQEAAFAoFunfvjrVr1z7wmKdPn4aPjw8A4O+//0ZkZOR9X/Phhx8iOztb8/P69evx3nvvPXAtRETU+rS6NTB1efhh44x79Kh+102dOhUVFRU4efIkrK2toVQqMWTIEFRXV2PatGkGvWd1dTXMzWv/Y/3666+hUChw5coVBAUFITIyEkFBQZrzNTt4N+Z5OZ6enjh8+PB9r/vwww8RExMDd3d3AMDzzz9v8HsREZEJFRUBP/8MjBunPbZjBzBkCGBv36SlMMAASEw03XtfvHgRu3fvRlZWFqytrQGoZ0w++OADPP/885g2bRri4uLwyiuvIC0tDYB69mPYsGFQKpVQKpVQKBSYNWsW9u/fj8mTJ+OVV16p9/06deqEgIAAXLhwAd999x3+/PNPlJaWIisrC/v378fp06exdOlS3L59G2ZmZlixYgX69+8PAFi8eDG++uor2NnZYciQIZoxa2ooLCwEABw9ehT/+Mc/UFJSAkEQsHTpUpw8eRJ///03nn76abRr1w6bNm3C7t27UVhYiA8//BB37tzBggUL8PPPPwMA+vfvjw8++AAWFhaYOnUqLC0tkZ6ejqysLAQGBmLHjh2wsLAQ/x8IERHVragIGDxY/aWZmwu89BLw0UfAyy8D4eHAvn1NGmJM1kK6u62hUCjw9ddfA1B/oUdERKBLly4IDQ3FmTNnNK9p6JxUpaamwt/fH87OzjrHH374YWRlZeHGjRv3HaOoqAg9evTAiRMnGgwvAPDnn3/i3Llz6NWrFwB12Ni8eTPOnj2LiooKLF68GHv37kVKSgq2bduG8ePHo6KiAj/99BP++9//IiUlBcnJyVAqlXWOn5+fj1GjRuGdd97ByZMnkZaWhsjISCxatAienp74+uuvkZaWBoVCofO6zz77DElJSUhJSUFaWhouXbqEVatWac6npaXhxx9/xF9//YWcnBzs3Lnzvp8LERGJ5O7wAqhDi5+f+q+A+vjgwerrmohJ18DUfJmlpaXh6aefBgDMmjULM2fOxIULFzB//nxMnTpVc31D51qzNm3aYOLEiQ1e8/TTT2tmar744gv4+/sDAIYOHQo3NzcAwL59+5Ceno6oqCgoFAo88cQTkMvlyMzMxG+//YannnoKdnZ2kMlkmDVrVp3vc/ToUQQEBGjWxMjlcjg5Od33dzhw4IBmpsXc3BwzZszA/v37NedHjx4NKysrmJmZISwsDJcuXdLrsyEiogd0b3ipce+/h5s4xDSrFlJubi6Sk5Px66+/AgDGjh2L2bNnIz09HXZ2dvWe8/PzM2XZDyQ4OBgXL15EXl6ezizM0aNH4eXlhfbt28Pc3Bx37tzRnCsvL9cZw8rK6r5rV2rWwNzr7lvKBUHAo48+im3btt237ob2pxDDveO3bdtW8/dmZmZ8ECERUVP5+Wf911okJtZeI2MkJg0wkydPhiAICAsLw7vvvousrCx4eHhoFqHKZDJ4e3sjMzMT9vb29Z570AATHv7Av0qj+fv7Y/jw4Zg5cya2bNkCKysrKJVKvPbaa1i4cCEAwNfXF1euXMGNGzfQvn17bNmyxSi1PP7443j77bdx6tQpzQLf48ePIywsDIMGDcK8efMwZ84c2NjY4LPPPqtzjIiICFy8eBGHDx9GZGQkVCoVCgsL4eTkBDs7OxTVk8wHDRqEzZs3Y/z48ZDL5fjPf/6Dxx57zCi/JxERGWDcOPWal5p2UUNWr26S8AKYMMAkJCTA29sbVVVVePPNNzFlyhQsXbrUJLXoe7eQsWzevBlvvvkmevbsCQsLC5iZmeEf//gHnnvuOQDqu3zmzZuHsLAwuLm56SygFZOfnx+2bduGWbNm4datW6isrERwcDC2bduGoUOH4vjx4wgJCam1iPdujo6O2LVrF1577TWUlJRALpdj6dKlGD58OF566SXMmDEDVlZW2LRpk87rZs6ciUuXLiEkJAQAEBMTc9/1PERE1ERqFuw21L7v3Fl9XRORCYIgNNm71eP69evo0qULLl26BD8/P+Tn58Pc3ByCIMDDwwNHjhyBnZ1dvefunoFRqVQoKSnRGd/W1lbTYsnKyoKXl1eT/n7UdPjPl4jICGruNrqf1asbHWLu9/19L5Ms4i0rK9PccgsA27dvR3BwMFxdXRESEoKtW7cCAHbu3ImOHTvCz8+vwXNERERkJDt26BdeAPV1O3YYt57/MckMzOXLlzF27FjcuXMHgiDA19cXq1evho+PD86fP4+pU6ciLy8PdnZ22LhxI3r27AkADZ6rwRmY1o3/fImIRFbfXUh1eYDnwRg6A9MsWkhiYoBp3fjPl4jICOoKMZ07666JecCH2UmihUREREQSYm+vDic1t+2uXg2kp6v/CpjkSbzN6jkwRERE1EzVhJi7n/Py0kuAqyv3QiIiIqJmzN6+9nNemui5L/diC0kfRUW1V1Xv2NGkez4QERGRFgPM/dQsXHrmGfV98ID6r888I+qeDyUlJbCxscG0adP0uj4uLg779u174PdVKpVwcHCodfz48eNwd3ev9cj+Xbt2aZ7SWx8fHx/NztlERETGwADTkCbcffPrr79G79698d1336G0tPS+14sVYOoTFhaG9u3b4+eff9Y5vmHDBr1DFhERkbEwwNSniXff3LBhA+bPn4+oqCh8/fXXd5VRhOnTpyMwMBC9evXCc889h7S0NKxfvx5fffUVFAoFlixZUmsmpbS0VGdDxAkTJqBPnz4ICgpCbGwssrOz71vTtGnT8MUXX2h+vn79Og4dOoSJEydi5cqVCA0NhUKhQGhoKI7Wsx9DTEwMdu/erfn5iSee0GwjUFJSghkzZiAsLAxBQUGYOXMmKisrAQDLli1Dt27doFAooFAocOXKFX0+RiIiaiUYYOrTmN03G+ns2bPIysrC448/jmnTpmHDhg2ac6+88gosLCxw6tQpnDx5EitWrIBCocDzzz+PCRMmIC0tDYsWLbrve3z44YdITk7GqVOnEBkZicWLF9/3NRMnTsT+/ftx48YNAMCXX36JYcOGwdnZGZMmTUJSUhLS0tKwZs0aPPvsswb/3q+99hoiIyNx/PhxnDx5EiqVCqtXr0ZBQQHef/99nDhxAmlpafjjjz/g5uZm8PhERNRy8S6k+jTh7psbNmzA5MmTYWZmhqFDh2LWrFn466+/0K1bN+zZswfHjh3TPMinffv2jXqPbdu2YcuWLSgvL0d5eTlcXFzu+xoXFxcMHToUW7ZswZw5c7Bx40asWbMGAJCamop//etfyMvLg7m5Oc6fP4/bt2+jXbt2ete0e/duHD16FCtXrgQA3L59G2ZmZrCzs4O/vz8mTpyIxx57DLGxsejYsWOjfm8iImqZGGAa0gS7b1ZVVWHLli1o06YNtm3bBgC4desWNmzYgPfff1/vcczNzXHnzh3Nz+Xl5Zq/P3LkCD766CMcPXoUrq6u+OGHH/SatQHUbaS5c+ciLCwM5eXlGDRoECorKzFmzBgcOnQIoaGhKC4uhr29PSoqKmoFmIbqEgQBO3fuRJcuXWq9b2JiIv744w/ExcUhPDwc27dvR2RkpN6fBxERtWxsITXkfuEFUJ+vuTupEX744Qf4+vri2rVrUCqVUCqVSExMxJYtW1BVVYURI0bg/fffh0qlAgBNO8fOzg5Fd627cXd3hyAIOHv2LABg8+bNmnMFBQWwtbWFs7MzKisr8emnn+pd36OPPoqioiK8+uqrePbZZyGXy1FeXo7Kykp4e3sDgGZWpi5+fn44duwYACAjIwNHjhzRnBs1ahRWrFihudOpoKAA6enpKCkpQU5ODiIjI7Fw4UL069cPqampetdMREQtHwNMfZpo980NGzZgwoQJOse6deuGDh064Mcff8SqVatQUVGBnj17QqFQ4I033gAAjB49GmlpaZpFvObm5lizZg2GDRuG0NBQVFVVacYbPHgwAgICEBAQgMjISCgUCr3rk8vlePbZZ5GSkqJZ52JnZ4dly5YhLCwMvXv3hoWFRb2vnzdvHg4dOoSePXvi9ddfR9++fTXnVq1ahXbt2kGhUCAoKAgDBw6EUqlEUVERxowZg549eyIoKAhVVVWYMmWK3jUTEVHLx80c69NEu2+SuLiZIxGRNHEzR7Hcu3FVjc6ddX9meCEiImpyDDANaYa7bxIRERHvQrq/Zrb7JhERETHA6KcZ7b5JRERErbCFZG5urtdeQyQtgiDgxo0bsLS0NHUpRETUBFrdDIybmxtycnJQUFBg6lJIZPb29rCzszN1GURE1ARaXYCRy+Xw8PAwdRlERET0AFpdC4mIiIikjwGGiIiIJIcBhoiIiCSHAYaIiIgkhwGGiIiIJIcBhoiIiCSHAYaIiIgkhwGGiIiIJIcBhoiIiCSHAYaIiIgkhwGGiIiIJIcBhoiIiCSHAYaIiIgkhwGGiIiIJIcBhoiIiCSHAYaIiIgkhwGGiIiIJIcBhoiIiCSHAYaIiIgkhwGGiIiIJIcBhoiIiCSHAYaIiIgkhwGGiIiIJIcBhoiIiCSHAYaIiIgkhwGGiIiIJIcBhoiIiCTH5AFm48aNkMlk2L17NwAgJiYGDz30EBQKBRQKBVatWqW5Njc3F4MHD4a/vz8CAwORkJBgoqqJiIjIlMxN+eZKpRKff/45wsPDdY6vWrUKo0aNqnX9ggULEB4ejn379iEpKQmjR49GRkYG2rRp00QVExERUXNgshkYlUqF6dOnY82aNbC0tNTrNd988w2ef/55AEBoaCg8PT0RHx9vzDKJiIioGTJZgFm5ciUeeeQR9O7du9a5BQsWoGfPnnj66adx+fJlAEBeXh6qqqrg7u6uuc7HxweZmZlNVjMRERE1DyZpIZ0+fRo7d+6scw3Lli1b4OXlBUEQsHbtWgwbNgxnz541QZVERETUXJlkBubw4cNQKpXw9/eHj48PEhMTMXPmTKxbtw5eXl4AAJlMhtmzZ+Py5cvIy8uDs7MzzM3NkZ2drRlHqVTC29vbFL8CERERmZBJAswLL7yA69evQ6lUQqlUIjw8HJ999hlmzJiBnJwczXU7d+6Em5sbnJ2dAQBPPvkk1q9fDwBISkrCtWvXEB0dbYpfgYiIiEzIpHch3auiogKxsbGoqKiAXC6Hi4sLfvjhB835FStWYNKkSfD394eFhQW2bt3KO5CIiIhaIZkgCIKpixCTSqVCSUmJzjFbW1vI5SZ/5A0RERHVw9Dvb36rExERkeQwwBAREZHkMMAQERGR5DDAEBERkeQwwBAREZHkMMAQERGR5DDAEBERkeQwwBAREZHkMMAQERGR5DDAEBERkeQwwBAREZHkMMAQERGR5DDAEBERkeQwwBAREZHkMMAQERGR5DDAEBERkeQwwBAREZHkMMAQERGR5DDAEBERkeQwwBAREZHkMMAQERGR5DDAEBERkeQwwBAREZHkmBv6ApVKhXPnziE/Px9OTk7o2rUr5HLmICIiImo6eiePEydOYOLEiXByckJgYCCioqIQGBgIR0dHTJgwASdOnDBmnUREREQaegWYZ599FsOHD0eHDh2wa9cu3LhxA5WVlbhx4wa+//57eHl5Yfjw4Xj22WeNXS8RERERZIIgCPe7aOXKlZg9ezYsLCzqvaayshJr167Fq6++KmqBhlKpVCgpKdE5ZmtryzYXERFRM2bo97deAUZKGGCIiIikx9Dvb4O/1S9evIgbN24AAMrKyrBw4UK8/fbbKC8vb0S5RERERIYzOMCMHz8e169fBwC8+eab2LVrF3bt2oXXXntN9OKIiIiI6mJwC8nJyQk3b96EXC6Ht7c34uLiYGNjg+DgYFy7ds1YdeqNLSQiIiLpMfT72+DnwAiCAJlMhsuXL0Mul8PX1xcAUFxc3IhyiYiIiAxncIDp1asX/vWvfyEzMxOPPfYYAODatWuws7MTvTgiIiKiuhgcYD766CO8+OKLsLS0xKZNmwAABw4cwKOPPip2bURERER1MmgNTHV1Nb777juMGDECbdu2NWZdjcY1MERERNJj9OfA2Nra1nqD5oQBhoiISHqM/hyYoKAgnD9/vnHVEREREYnA4DUwTz75JEaPHo05c+bAx8dHJxkNGDBA1OKIiIiI6mJwC6neXpRMhjt37ohS1INgC4mIiEh6jP4cGJVK1bjKiIiIiETCaQkiIiKSHINnYADgr7/+wsGDB5Gbm4u7O1BLliwRrTAiIiKi+hgcYL799luMHz8e3bt3x9mzZ9G9e3ecOXMG/fr1M0Z9RERERLUY3EJatmwZPv30U6SlpcHa2hppaWlYuXIlIiMjjVEfERERUS0G34VkZ2eHgoICmJmZwcHBAYWFhaisrISvry+uXr1qrDr1xruQiIiIpMfoD7KzsrJCZWUlAMDJyQnXrl1DdXU1ioqKGlEuERERkeEMDjChoaH45ZdfAACDBg3C+PHjMXbsWISEhIheHBEREVFdDA4wn3/+OUJDQwEA//73v9G1a1c4ODjgiy++aFQBGzduhEwmw+7duwEAubm5GDx4MPz9/REYGIiEhATNtQ2dIyIiotbD4LuQ3N3dNX/v4OCATz/9tNFvrlQq8fnnnyM8PFxzbMGCBQgPD8e+ffuQlJSE0aNHIyMjA23atGnwHBEREbUeegWYgwcP6jWYIXshqVQqTJ8+HWvWrMFrr72mOf7NN98gPT0dgLpd5enpifj4eAwaNKjBc0RERNR66BVg9AkIhu6FtHLlSjzyyCPo3bu35lheXh6qqqp0Znl8fHyQmZnZ4DkiIiJqXfQKMGLvf3T69Gns3LmTa1iIiIioUUzycJTDhw9DqVTC398fPj4+SExMxMyZM/HNN9/A3Nwc2dnZmmuVSiW8vb3h7Oxc7zkiIiJqXfR6kN2iRYv0GqyxeyHFxMTglVdewahRozB16lT4+Phg8eLFSEpKwqhRo6BUKtGmTZsGz9Xgg+yIiIikx9Dvb71aSIcPH77vNTKZTJ+h7mvFihWYNGkS/P39YWFhga1bt2oCSkPniIiIqPUweCuB5o4zMERERNJj9K0EauTm5iI5ORm5ubmNHYKIiIioUQwOMMXFxRg9ejTc3d0RFhYGDw8PjB49mnshERERUZMxOMDMmzcPBQUFOHHiBIqLi5GSkoKioiLMnz/fGPURERER1WLwGhhvb28kJSXBzc1Ncyw7OxuhoaHIysoSvUBDcQ0MERGR9Bh9Dczt27fh4OCgc8zBwQG3b982dCgiIiKiRjE4wISGhmLhwoWap/OqVCosXrwYffr0Eb04IiIioroY3EI6d+4cBg0ahKqqKnTq1AmZmZkwNzfH/v370a1bN2PVqTe2kIiIiKTH0O/vRj0HprS0FD/++COuXr0KLy8vxMbGwtbWtnEVi4wBhoiISHqaJMA0ZwwwRERE0mOUrQT03eNI3z2TiIiIiB6EXjMwkZGROj8fO3YMjo6O8Pb2RlZWFvLz8xEeHo6EhASjFaovzsAQERFJj9E3c3zjjTfQv39/LF68GHK5HCqVCm+//Taqq6sfoGwiIiIi/Rm8BsbNzQ1Xr17V2QW6srISXl5eyMnJEb1AQ3EGhoiISHqM/iA7uVyOy5cv6xzLyMiATCYzdCgiIiKiRtGrhXS3SZMmYciQIZg7dy58fHygVCrxwQcfYNKkScaoj4iIiKgWgwPMO++8AwcHB3z44Ye4evUqOnbsiOeee46bORIREVGT4XNgiIiIyOSMvgaGiIiIyNQYYIiIiEhyGGCIiIhIcvQKMGfOnDF2HURERER60yvAPPzww5q/79mzp9GKISIiItKHXgGmXbt2yM7OBgAolUpj1kNERER0X3o9B2b8+PHw8fGBq6srbt++DW9v7zqvy8zMFLU4IiIiorro/RyYxMREpKenY8aMGVi/fn2d10yZMkXU4hqDz4EhIiKSHqPsRg0A4eHhCA8PR3p6erMIKkRERNR6NepJvIIgICkpCZmZmfD29kZoaGiz2cyRMzBERETSY7QZmBrXr1/HiBEjcOLECTg6OqKgoAAhISH4/vvv4enp2biqiYiIiAxg8LTEq6++Cl9fX9y4cQM3b97EjRs34Ofnh1dffdUY9RERERHVYnALycPDA+fPn4ednZ3mWFFREQICAjS3WpsSW0hERETSY/TNHAVBqDWYXC5HC9vUmoiIiJoxgwNMdHQ0nn/+eRQXFwNQz768+OKLiI6OFr04IiIioroYvIh31apViI2NhZOTE5ycnFBQUIDAwEDs2bPHGPURERER1dKo26hVKhWOHz+OrKwseHl5ISwsrNmsMeEaGCIiIukx9Pu7UQGmOWOAISIikh6jL+IlIiIiMjUGGCIiIpIcBhgiIiKSHAYYIiIikhyDA8zatWuRlpYGADhx4gS8vLzw0EMPISUlRezaiIiIiOpk8F1Ivr6+SExMhKurK2JjY9G1a1fY2NggISEBhw4dMladeuNdSERERNJj9Nuo7e3tUVRUhOrqari4uODvv/+GhYUF3NzckJeX1/jKRcIAQ0REJD2Gfn8b/CReKysrFBQU4PTp0+jatSusrKxQVVWFqqqqxlVMREREZCCDA8zo0aMxaNAglJaWYtasWQCAU6dOoVOnTqIXR0RERFQXg1tIVVVV+PLLL2FhYYGJEydCLpfj0KFDyM3NxdNPP22sOvXGFhIREZH0cCsBBhgiIiLJMeoamBMnTmDdunVITU1FcXEx7OzsEBwcjBdeeAEhISGNr5qIiIjIAHpPS+zatQv9+vVDXl4exo4dizlz5mDs2LHIz89HZGQkdu/ebdAbP/bYYwgKCoJCoUBkZCRSU1MBAD4+PggICIBCoYBCocDXX3+tec3FixcRERGBLl26IDQ0FGfOnDHoPYmIiKhl0LuF1KNHDyxduhRjxoypdW7Xrl345z//ibNnz+r9xoWFhXBwcNC8fvHixTh58iR8fHywe/duKBSKWq8ZMGAAJk+ejKlTp+Lbb7/FihUrkJSUpHMNW0hERETSY7TdqJVKJUaOHFnnueHDh0OpVOpfJaAJLwBQVFQEmUzW4PW5ublITk7GxIkTAQBjx45FVlYW0tPTDXpfIiIikj69A4y3tzd+/PHHOs/99NNPjbqNevLkyfDy8sLChQuxZcsWneM9e/bEtGnTcOPGDQBAVlYWPDw8YG6uXrYjk8ng7e2NzMxMg9+XiIiIpE3vRbxLly7FM888g6FDhyIsLAwODg4oLCxEUlIS9u7dqxNA9LV582YAwJdffon58+dj7969SEhIgLe3N6qqqvDmm29iypQp2Lt3r8FjExERUctl0G3Ux44dw6effoq0tDTNXUgKhQKzZs1C3759H6iQdu3a4erVq3B2dtYcu379Orp06YKSkhLk5ubCz88P+fn5MDc3hyAI8PDwwJEjR+Dn56d5DdfAEBERSY9Rb6Pu27fvAwcVQL2A99atW/D09AQA7N69G87Ozmjbtq3O4t7t27cjODgYAODq6oqQkBBs3boVU6dOxc6dO9GxY0ed8EJEREStg8FbCVy9elUzA2Nvbw+FQoEOHToYNEZRURGefPJJ3L59G3K5HO3bt8eePXuQk5ODsWPH4s6dOxAEAb6+vpo2EwB8+umnmDp1KpYvXw47Ozts3LjR0PKJiIioBdC7hVRUVIQpU6bghx9+gIWFhWYNTFVVFUaMGIEvv/wSdnZ2xq73vthCIiIikh6j3UY9e/ZslJWVIS0tDeXl5cjOzkZ5eTlSU1Nx69YtzJ49+8EqJyIiItKT3jMwTk5OSE9Ph5OTU61zN2/ehL+/PwoKCkQv0FCcgSEiIpIeo83AqFSqeh82J5PJ0ML2hCQiIqJmTO8AExsbi6effhqnT5/WOX769GlMmDABw4YNE704IiIiorroHWDWrl2LNm3aICgoCFZWVvDw8ICVlRV69eqFNm3a4OOPPzZmnUREREQaBj3IDgCuXLmCtLQ0lJSUaB5k5+3tbaz6DMY1MERERNJj6Pe3wQGmuWOAISIikh6jPon3xIkTWLduHVJTUzVbCQQHB+OFF15ASEhI46smIiIiMoDe0xK7du1Cv379kJeXh7Fjx2LOnDkYO3Ys8vPzERkZid27dxuxTCIiIiItvVtIPXr0wNKlSzFmzJha53bt2oV//vOfOHv2rOgFGootJCIiIukx2hoYa2trFBcXw8zMrNa56upq2NnZ4datW40oWVwMMERERNJjtAfZeXt748cff6zz3E8//YROnToZUCYRERFR4+m9iHfp0qV45plnMHToUISFhWk2c0xKSsLevXuxZcsWY9ZJREREpKF3gHniiSfg5eWFTz/9FF9//bXmLiSFQoFDhw6hb9++xqyTiIiISIPPgSEiIiKTM9oaGCIiIqLmQpQAU1FRUefdSURERETGINoMTAvrRBEREVEzpvci3qioqHrPCYIAmUwmSkFERERE96N3gDl27BhmzpwJFxeXWueqqqrwxx9/iFoYERERUX30DjA9evTA4MGDERsbW+tceXk5li9fLmphRERERPXRew1MbGwsbt68Wec5c3NzTJkyRbSiiIiIiBrC58AQERGRyfE5MERERNTiMcAQERGR5DDAEBERkeQwwBAREZHkMMAQERGR5Oj9HJi7Xb58GSkpKbVWCz/33HOiFEVERETUEINvo16/fj1mz54NJycnWFtbaweSyXD58mXRCzQUb6MmIiKSHkO/vw0OMJ06dcKqVaswZsyYxldpRAwwRERE0mP0AOPg4IDCwsJGF2hsDDBERETSY/QH2cXGxiI+Pr5x1RERERGJwOBFvO3bt8eoUaMwduxYeHp66pxbsmSJaIURERER1cfgAHPy5EkoFApcunQJly5d0hyXyWSiFkZERERUH27mSERERCbHzRyJiIioxdOrhTR48GDs27cPABAZGVlvuyghIUG8yoiIiIjqoVeAiY6O1vz9oEGDjFYMERERkT64BoaIiIhMjmtgiIiIqMXTK8AoFAr8+OOPqG+yRhAEfP/99wgODha1OCIiIqK66NVC+v333/HSSy8hJycHAwcORGBgIOzt7VFUVIQzZ87gt99+g6urKz766CM88sgjTVF3vdhCIiIikh6j7oV06NAhfPfdd0hOTkZ+fj6cnJzQu3dvjBkzBgMGDHiwykXCAENERCQ9Rt/MsbljgCEiIpIeLuI1lqIiYMcO3WM7dqiPExERUZNigNFHUREweDDwzDPARx+pj330kfrnwYMZYoiIiJqYyQLMY489hqCgICgUCkRGRiI1NRUAcPHiRURERKBLly4IDQ3FmTNnNK9p6JzR1ISXxET1zy+/DPj5qf8KqI8zxBARETUpkwWYb775BqdOnUJaWhrmzJmDqVOnAgBmzZqFmTNn4sKFC5g/f77m+P3OGcW94aXGXbtwA2CIISKiFq2qCjh2DFixAhg6FPjPf0xdUTNZxLtp0yZ8+OGH+PXXX+Hn54f8/HyYm5tDEAR4eHjgyJEjsLOzq/ecn5+fZixRF/Hu2KFuE+lr+3Zg3DjD34eIiKgZqaoCkpOB+HggLg74/XegtFR7fswYYOdOcd/T0O9vvfZCuvcNVqxYgS+++AK5ubkoKirCL7/8gszMTMyYMcOgsSZPnoxDhw4BAPbu3YusrCx4eHjA3Fxdlkwmg7e3NzIzM2Fvb1/vubsDjKjGjQNyc7XtooasXs3wQkREklRZqQ4scXHq0PL770BZWf3Xx8cDKhVgyht8DX7rxYsX45tvvsHbb7+t2ZXaz88P69atM/jNN2/ejKysLCxbtgzz5883+PVN4qWXgM6dG76mc2f1dURERBJQUQEcOQIsWwY8+ijg4AA88gjwz38Cv/7acHgBgLw84OzZJim1Xga3kB566CEkJCTAy8sLTk5OyM/Ph0qlgouLC/Lz8xtdSLt27aBUKuHv7998WkiA+m4jfWdgGGKIiKgZqqhQr2GpaQkdPQrcvv1gY65ZA8yeLUp5AJqghVRSUoKOHTvqHLtz546mtaOPwsJC3Lp1C56engCA3bt3w9nZGa6urggJCcHWrVsxdepU7Ny5Ex07dtQElIbOGcWOHfqFF0B9nasr20hERGRy5eXqwFLTEjp6VH1MDG3aAKGhgLOzOOM1lsEBpmfPnvj222/x5JNPao4ZupFjUVERnnzySdy+fRtyuRzt27fHnj17IJPJ8Omnn2Lq1KlYvnw57OzssHHjRs3rGjpnFEOGAOHhte9Cqkt4uPp6IiKiJnb7tvqrqmaGJTFRPesihjZtgL59gZgYIDoaePhhwNpanLEfhMEtpGPHjmHQoEEYMWIEdu3ahfHjx+Pbb7/F/v37ERoaaqw69SZ6C6muW6k7d9a9lTo8HNi3D7C3b9x7EBERGeDWLfWsSk1gOXZMvRBXDBYW6q+16Gh1aAkPB6ysxBm7IU2yF9L58+fxySef4OLFi3B3d8eLL76IPn36NK5ikRllL6S7Q0zNWpeatTEML0REZGRlZerAUtMSOnZMfauzGCwt1V9lNTMs4eFAu3bijG0IbuZorM0ci4qAn3/WXeOyY4e6bcTwQkREIiotBf74QzvDcvw4UF0tztht26rbQDWBpW9f9TFTM3qAee+99xAVFYW+fftqjiUmJuLIkSOYO3duI0oWF3ejJiIiqSktVT97JS5O/Sc5WbzA0q4dEBGhbQmFhalnXZobowcYb29vnDp1Cg4ODppjBQUF6NWrFzIzMw2vWGQMMERE1NwVF2sDS3y8OrDcuSPO2FZW6sBSM8MSGto8A8u9jH4bdWFhoU54AQBHR0cUFBQYOhQREVGrUFSkfnBcTUsoJUX9JFsxWFkB/fppA0ufPuqFuC2dwQHGy8sLKSkp6N27t+ZYSkoKOnToIGphREREUlVYqA4sNS2h1FTxAouNjTqw1LSEevdW3+rc2hgcYKZNm4ZnnnkGK1asQJcuXXDhwgW8/vrrmD59ujHqIyIiavYKCoDDh7UtodRUQKxbZGxtdWdYQkJaZ2C5l8EB5uWXX0Z+fj6mTJmC0tJS2NjY4P/+7/8wZ84cY9RHRETU7OTnAwkJ2pbQyZPiBRY7OyAyUjvDEhwMGPCw+1bjgW6jvnnzJlxcXMSs54FxES8REYktL08dWGpaQn/+KV5gsbcHoqK0gUWhAMzMxBlbSoy+iPduzS28EBERieHGDW1giY9XBxaxODioA0tNS6hXr9YZWB6UXgGmW7du+OuvvwCoF/HKZLI6r2sOt1ETEREZKjdXHVRqWkJnzog3tqOjOqjUzLD07MnAIga9AszChQs1f79s2TKjFUNERNQUcnK0YSUuDvjff6OLwtlZO8MSEwMEBgJcxSA+vQLM+PHjAQDV1dVo164dRo4cCUspPBWHiIgIwPXr2sASHw+cOyfe2C4u2tmV6GigRw8GlqZg8CJeW1vbWotsmhMu4iUiomvXdFtCFy6IN3b79tqwEhMDdO8O1LOyggxg9EW8QUFBOH/+PAICAhpXIRERkciuXtWdYbl4Ubyx3dy0YSUmBujalYGlOTA4wDz55JMYPXo05syZAx8fH51kNGDAAFGLIyIiqktmpm5guXRJvLE9PHRbQgEBDCzNkcEtpHp3hZTJcEesnageAFtIREQtz5Ur2rASFwdkZIg3tqenbkvI35+BxRSM3kJSibWZAxERUR0EAVAqdWdYlErxxu/QQdsOiokBOndmYJEigwJMQkICUlJSEBYWhkceecRYNRERUSsiCOoZlZpbmuPj1S0isXh5acNKdDTg68vA0hLoHWC++OILTJ8+Hc7OzigoKMCmTZswceJEY9ZGREQtkCCo16zc3RK6elW88Tt10m0J+fgwsLREeq+BCQoKwvz58zFhwgRs2bIFH330EZKSkoxdn8G4BoaIqHkRBPVdQXe3hK5dE2/8hx7SXXTr4yPe2NR0DP3+1jvAODg4oKCgQLNY18PDA7m5uQ9escgYYIiITEsQ1M9duXuG5fp18cb39dVtCXl7izc2mY7RFvGqVCrNHkhmZmaorq5+gDKJiKilEAT1k21rAkt8PJCdLd74fn7asBIdrV7TQqR3gKmoqMCiRYs0P9++fVvnZwBYsmSJeJUREVGzJAjA2bO6LSExJ+S7dNFtCXXoIN7Y1HLo3UKKiYmpdxdqQP0cmIMHD4pWWGOxhUREJC6VSh1Y7p5huXFDvPEDArQtoago9XNZqPUx2hoYqWCAISJ6MCoVcPq07gxLXp5443frptsScncXb2ySLqM/yI6IiFoWlQo4dUobWBISgPx88cbv0UPbEoqKUu8tRPSgGGCIiFqZO3fUgaVmdiUhASgoEG/8wEDdllD79uKNTVSDAYaIqIW7cwdIS9OdYSkqEm/8oCBtSygqCnBxEW9sovowwBARtTDV1UBqqjawHD4MFBeLM7ZMBvTqpW0JRUYCzs7ijE1kCAYYIiKJq64GTpzQtoQOHwbuWQvZaDIZoFBoW0KRkYCjozhjEz0IBhgiIompqgJSUrQzLEeOAKWl4owtlwPBwdoZln79GFioeWKAISJq5iorgeRkbWD5/XegrEycseVyoHdv3cBiby/O2ETGxABDRNTMVFYCSUnaltDvvwO3bokztpmZOrDULLrt1w+wsxNnbKKmxABDRGRiFRXA8ePaGZY//gBu3xZnbDMzIDRUO8PyyCOAra04YxOZEgMMEVETKy8Hjh3TBpajR9XHxGBurg4sNYtuIyIAGxtxxiZqThhgiIiMrLwcSEzUtoSOHlXPuoihTRsgLEzbEoqIAKytxRmbqDljgCEiEtnt2+qQUjPDcuyYeIHFwgLo21fbEnr4YcDKSpyxiaSEAYaI6AHduqVet1ITWI4fVy/EFYOFBRAerm0JhYcD7dqJMzaRlDHAEBEZqKxMHVhqWkLHj6ufzSIGS0v1rEpNS6hvXwYWorowwBAR3UdpqfpW5poZlqQk9dNvxdC2rXrdSk1LKCxMfYyIGsYAQ0R0j5ISdWCJi1P/SU5Wb4gohnbt1IGlpiUUGqqedSEiwzDAEFGrV1ysfhx/TUsoJUW8wGJlpX72Sk1LKDRUva6FiB4MAwwRtTpFReoND2taQidOACqVOGNbW6ufblvTEurdm4GFyBgYYIioxSssVAeWmhmW1FTxAouNjTqw1LSEQkLUz2YhIuNigCGiFic/X3eGJS0NEARxxra1BSIjtS2hkBD102+JqGnx/3ZEJHl5eUBCgjawnDolXmCxswOiorQtIYWCgYWoOTDJ/w3Ly8sxbtw4nD17Fu3atYOrqyvWrVsHPz8/xMTE4MqVK7D/337uU6ZMwauvvgoAyM3NxeTJk3Hp0iVYWlrik08+QVRUlCl+BSIyoZs31YGlpiV06pR4Yzs46M6wKBTqDRGJqHkx2X9HzJw5E0OGDIFMJsPHH3+M6dOnIy4uDgCwatUqjBo1qtZrFixYgPDwcOzbtw9JSUkYPXo0MjIy0IYNZ6IWLTdXd4bl9GnxxnZ0VM+w1ASWoCAGFiIpMEmAadu2LYYOHar5OTw8HO+///59X/fNN98gPT0dABAaGgpPT0/Ex8dj0KBBRquViJpeTo46rNQElrNnxRvbyUkdVGpaQj17AnK5eOMTUdNoFp3c1atXY+TIkZqfFyxYgIULF6J79+5455134Ovri7y8PFRVVcHd3V1znY+PDzIzM01RMhGJKDtbG1bi44G//hJvbGdnbViJjgYCAxlYiFoCkweY5cuXIz09Hb/99hsAYMuWLfDy8oIgCFi7di2GDRuGs2L+5xcRmdzff+vOsJw/L97Y7dvrBpbu3RlYiFoikwaY999/H9999x0OHDgAq//tB+/l5QUAkMlkmD17NubOnYu8vDw4OzvD3Nwc2dnZmlkYpVIJb29vk9VPRPq5dk07uxIXB1y8KN7Yrq7asBITA3TrBshk4o1PRM2TyQLMypUrsX37dhw4cAAODg4AgOrqauTl5cHNzQ0AsHPnTri5ucHZ2RkA8OSTT2L9+vVYvHgxkpKScO3aNURHR5vqVyCiemRl6baE/rd0TRTu7rozLF27MrAQtUYyQRDraQn6u3r1Kry8vODr6wtbW1sAgKWlJQ4ePIjo6GhUVFRALpfDxcUFK1euRK9evQAAOTk5mDRpEjIyMmBhYYGPP/4Y/fv31xlbpVKhpKRE55itrS3knEMmMprMTN0ZlsuXxRvbw0N3hqVLFwYWopbI0O9vkwQYY2KAITI+pVI3sCiV4o3doYNuYPHzY2Ahag0M/f42+SJeImreBEEbWGpCy5Ur4o3fsaN2H6HoaKBzZwYWIro/Bhgi0iEI6hbQ3TMsWVnije/trTvD8tBDDCxEZDgGGKJWThDUi2zvDizXrok3vo+PNqzExKh/JiJ6UAwwRK2MIKhvY767JfT33+KN7+ure5dQp07ijU1EVIMBhqiFEwT1g+LunmHJzhZv/M6dtWElOlrdIiIiMjYGGKIWRhDUj+KvCSzx8eq9hcTi7687w9Kxo3hjExHpiwGGSOIEQb3Z4d0toRs3xBs/IEA3sHh6ijc2EVFjMcAQSYxKBZw5ozvDcvOmeON37arbEvLwEG9sIiKxMMAQNXMqFfDnn9r1KwkJQF6eeON3766dYYmKUj+qn4iouWOAIWpmVCrg1CltSyghASgoEG/8Hj20tzRHRak3QyQikhoGGCITu3MHOHlS2xJKSAAKC8Ubv2dPbUsoKgpo3168sYmITIUBhqiJVVcDaWnaltDhw0BRkXjj9+qlbQlFRgIuLuKNTUTUXDDAEBlZdTWQmqqdYTl8GCguFmdsmUwdWGpaQpGRgJOTOGMTETVnDDBEIquqAk6c0AaWI0eAezZYbTSZDAgO1raEIiMBR0dxxiYikhIGGKIHVFUFJCdrW0K//w6UlooztlwOhIRoW0L9+gEODuKMTUQkZQwwRAaqrFQHlpoZlt9/B8rKxBnbzEwdWGpaQo88AtjbizM2EVFLwgBDdB8VFUBSkm5guX1bnLHNzIA+fbQtoUceAezsxBmbiKglY4AhukdFBXDsmLYldPSoeIHF3BwIDdW2hCIiAFtbccYmImpNGGCo1SsvVweWmhmWo0fVx8Rgbg6EhWlnWCIiABsbccYmImrNGGCo1bl9G0hM1AaWxET1rIsY2rQB+vbVzrA8/DBgbS3O2EREpMUAQy3erVvqWZWaltCxY+qFuGKwsADCw7WBJTwcsLISZ2wiIqofAwy1OGVl6sBSM8Ny7Jj6VmcxWFqqQ0pNSyg8HGjXTpyxiYhIfwwwJHmlpcAff2gDy/Hj6qffiqFtW3UbqGaGpW9f9TEiIjItBhiSnJIS9a3MNS2h5GTxAku7duqFtjWBJSxMPetCRETNCwMMNXvFxerAUjPDkpys3sFZDFZW6sBS0xIKDWVgISKSAgYYanaKitT7B9UElpQUQKUSZ2wrK/Xj+GtmWPr0US/EJSIiaWGAIZMrLNQGlrg49c7NYgUWGxvdwNK7t/pWZyIikjYGGGpyBQXA4cPaGZbUVEAQxBnb1lYdWGpaQiEhDCxERC0RAwwZXX4+kJCgXXR78qR4gcXODoiM1M6wBAern35LREQtG/9VT6LLy1MHlpqW0J9/ihdY7O2BqChtYFEo1BsiEhFR68IAQw/sxg1tYImPVwcWsTg4qANLTUuoVy8GFiIiYoChRsjNVQeVmpbQmTPije3oqA4qNTMsPXsysBARUW0MMHRfOTnasBIXB/z1l3hjOztrZ1hiYoDAQEAuF298IiJqmRhgqJbr17WBJT4eOHdOvLFdXLSzK9HRQI8eDCxERGQ4BhjCtWu6LaELF8Qbu317bViJiQG6dWNgISKiB8cA0wpdvao7w3Lxonhju7lpw0pMDNC1KyCTiTc+ERERwADTKmRm6gaWS5fEG9vdXXeGJSCAgYWIiIyPAaYFunJFG1bi4oCMDPHG9vTUDSz+/gwsRETU9BhgJE4QAKVSd4ZFqRRv/A4dtO2gmBigc2cGFiIiMj0GGIkRBPWMSs0tzfHx6haRWLy8dGdYfH0ZWIiIqPlhgGnmBEG9ZuXultDVq+KN36mTbmDx8WFgISKi5o8BppkRBPVdQXe3hK5dE2/8hx7SfQ6Lj494YxMRETUVBhgTEwT1c1fubgldvy7e+L6+2rASHa2ecSEiIpI6BpgmJgjqJ9ve3RLKyRFvfD8/3cDi5SXe2ERERM0FA4yRCQJw9qxuSyg3V7zxu3TRbQl16CDe2ERERM0VA4zIVCp1YKlpCSUkADduiDd+QIDuDIunp3hjExERSQUDzANSqYDTp7WzK/HxQF6eeON366Y7w+LuLt7YREREUmWSAFNeXo5x48bh7NmzaNeuHVxdXbFu3Tr4+fkhNzcXkydPxqVLl2BpaYlPPvkEUVFRANDguaaiUgGnTmlbQgkJQH6+eON37659aFxUlHpvISIiItJlshmYmTNnYsiQIZDJZPj4448xffp0xMXFYcGCBQgPD8e+ffuQlJSE0aNHIyMjA23atGnwXFN57z1gwQLxxgsM1M6uREUBrq7ijU1ERNRSyQRBEExdRHJyMp544gkolUrY2NggPT0d7v/rlYSFhWH58uUYNGhQg+dqqFQqlJSU6Ixva2sLuVwuSq1HjgCRkY1/fVCQtiUUFQW4uIhSFhERkaQZ+v3dLNbArF69GiNHjkReXh6qqqo0AQUAfHx8kJmZ2eC5phQaCrRrB9y+ff9rZTJ1YKlpCUVGAs7Oxq6QiIio5TN5gFm+fDnS09Px22+/4bY+qcDELC2Bhx8GDh6sfU4mAxQKbUsoMhJwcmrqComIiFo+kwaY999/H9999x0OHDgAKysrWFlZwdzcHNnZ2ZqZFqVSCW9vbzg7O9d7rqnFxKgDjFwOBAdrW0L9+gGOjk1eDhERUasjzsKQRli5ciW2b9+O/fv3w8HBQXP8ySefxPr16wEASUlJuHbtGqKjo+97rik98wywZ4/67qPkZOCDD4DhwxleiIiImopJFvFevXoVXl5e8PX1ha2tLQDA0tISx44dQ05ODiZNmoSMjAxYWFjg448/Rv/+/QGgwXM1jL2Il4iIiMRn6Pd3s7gLSUwMMERERNJj6Pc3v9WJiIhIchhgiIiISHIYYIiIiEhyGGCIiIhIchhgiIiISHIYYIiIiEhyGGCIiIhIchhgiIiISHIYYIiIiEhyTL4btdjqerCwSqUyQSVERESkr7q+qxvaLKBVBJiysjITVEJEREQPoqEAwxYSERERSQ4DDBEREUkOAwwRERFJjkxoqMEkQSqVqtZCIJlMBplMZqKKiIiI6H4EQai15kUul0Mur3uupcUFGCIiImr52EIiIiIiyWGAqcNLL70EHx8fyGQypKWl1Xvdhg0b4O/vj86dO2PGjBmoqqpquiJbCH0+64MHDyIsLAzdu3dHjx49MG/ePD7bx0D6/m8aUE/jDhgwAA4ODk1SW0ui7+f8559/IiYmBt26dUO3bt3w3XffNV2RLYA+n7NKpcKcOXPQvXt3BAUFoX///khPT2/aQiWuvLwco0aNQpcuXdCrVy88+uij9X6Ge/bsQdeuXeHv748xY8aguLjY6PUxwNThiSeewJEjR9CpU6d6r8nIyMDChQtx+PBhpKenIycnB5999lkTVtky6PNZOzo6YseOHTh79ixSUlLwxx9/YPPmzU1YpfTp8znXWLVqFTp37twEVbU8+nzOt27dwsiRI7Fs2TL89ddfOH36NCIjI5uwSunT53P+4Ycf8Pvvv+PkyZM4deoUBg4ciDfeeKMJq2wZZs6cifPnz+PkyZMYOXIkpk+fXuua0tJSTJs2Dbt378bFixfh6emJpUuXGr02Bpg6REVFoWPHjg1e8+2332LEiBFwd3eHTCbD888/j+3btzdRhS2HPp91cHAwfH19AQBt27aFQqGAUqlsgupaDn0+ZwA4c+YMdu/ejQULFjRBVS2PPp/ztm3bEB4ejn79+gEAzMzM0L59+6Yor8XQ53OWyWSoqKhAeXk5BEFAcXGxXv8fIK22bdti6NChmptgwsPD6/x3788//4zg4GB07doVAPDiiy82yfdhi3sSb1PJzMzUSf8+Pj7IzMw0YUWtQ3Z2Nr799lvs2bPH1KW0OFVVVZgxYwY2bNgAMzMzU5fTYp09exaWlpYYNmwYrl69iqCgIHzwwQcMMSIbPnw4Dh06BHd3d9ja2qJDhw6Ij483dVmStnr1aowcObLW8bq+D69fv47q6mqYmxsvZnAGhiSjuLgYw4cPx7x589CnTx9Tl9PivP322xgzZgy6detm6lJatOrqahw4cACffvopUlNT0aFDB7zwwgumLqvFSU5OxunTp3Ht2jX8/fffGDhwIJ5//nlTlyVZy5cvR3p6Ot555x1Tl6LBANNI3t7euHLliuZnpVIJb29vE1bUspWUlGDw4MEYOXIk5syZY+pyWqT4+HisWbMGPj4+6NevH4qLi+Hj44MbN26YurQWxdvbG/3790eHDh0gk8kwceJEJCYmmrqsFmfz5s2axehyuRxTpkzBoUOHTF2WJL3//vv47rvv8PPPP8PKyqrW+bq+Dz08PIw6+wIwwDTa2LFj8cMPPyA7OxuCIGD9+vUYN26cqctqkUpLSzF48GAMHjwYb775pqnLabEOHz6MK1euQKlU4siRI7Czs4NSqWRrQ2RPPfUUkpKSNHdp7N27F7169TJxVS2Pr68vDh48iMrKSgDqu2QCAwNNXJX0rFy5Etu3b8f+/fvrvTNx8ODBOHHiBM6dOwcA+OSTT5rm+1CgWmbOnCl06NBBMDMzE1xdXYXOnTsLgiAI06ZNE77//nvNdZ999png6+sr+Pr6Cs8995xQWVlpqpIlS5/PetmyZYK5ubnQq1cvzZ9ly5aZsmzJ0fd/0zUyMjIEe3v7Jq5S+vT9nDdv3iz06NFD6NmzpzB48GAhMzPTVCVLkj6fc3l5uTB9+nSha9euQs+ePYVHH31UuHTpkinLlpysrCwBgODr66v5d29YWJggCIKwcOFCYd26dZprv//+eyEgIEDo3LmzMHLkSKGwsNDo9fFJvERERCQ5bCERERGR5DDAEBERkeQwwBAREZHkMMAQERGR5DDAEBERkeQwwBAREZHkMMAQEQD1g+xsbGxw584do73Htm3bEBsba7TxmwulUonIyEjY2dkhIiKizmvKysrQqVMnXLhwoYmrI2oZGGCIWomMjAw888wz8PT0hI2NDTw9PTF06FBcv34dABAZGYnS0lKjbeRYXl6OuXPn4l//+pfm2G+//YaBAwfC2dkZMpkM6enptV6XmZmJYcOGwdbWFi4uLpg9e7bm6ao11q5dCx8fH1hZWSEkJAQJCQkGjyGmd955B46OjigsLMQff/yBTZs21doJ2draGnPmzMFrr71mtDqIWjIGGKJWYujQobC1tcXp06dRWlqK1NRUPP3005DJZE3y/tu3b0fHjh2hUCg0x6ytrTF58mRs3ry5zteoVCoMGzYMTk5OuHbtGlJSUpCQkIB//OMfmmv++9//4o033sCXX36JwsJCTJs2DUOHDkVWVpbeY4jt0qVLCAoKglze8L9iJ0+ejAMHDnAWhqgxjP6sXyIyuZs3bwoAhJSUlHqvOXTokABAqKqqEgRBENzc3ARra2vNH3NzcyE6Olpz/U8//SSEhYUJDg4Ogp+fn7B69eoGa4iNjRXefPPNOs9lZGQIAISLFy/qHI+LixPMzc2FGzduaI7t3r1bsLKyEm7fvi0IgiDExMQIr7zyis7rFAqFsGTJEr3HuFdaWpoQFRUl2NvbCw4ODkJISIhw7tw5QRAEoaqqSvjHP/4huLm5CS4uLsKCBQuERx55RHjrrbcEQRAEX19fQS6XC23atBGsra2FxYsXC5aWloJMJtN8llu3btW8V2RkpPDuu+82+NkRUW2cgSFqBZydndGzZ0/MmjULGzduxKlTp6BSqRp8TXZ2NkpLS1FaWorExETY2dnhueeeAwAcOnQI48ePx/Lly5GXl4ddu3bhvffew1dffVXveMnJyQZvppeWlgZfX1+4uLhojoWGhuLWrVuaWYu0tDSEhYXpvC40NBSpqal6j3GvF198EQMHDsTNmzdx48YNbNiwQbOR3b///W988803OHjwIK5evQpzc3McO3ZM89pLly4hMjIS8+bNQ2lpKd566y2sX78enp6ems9zwoQJmuuDgoKQlJRk0OdCRGwhEbUahw4dwpAhQ7Bu3TqEhYXBxcUFc+fORUVFRYOvu3LlCgYPHozXX38dkydPBgCsWrUKL7zwAgYOHAi5XI7AwEA8//zz2LhxY73j5Ofnw97e3qCai4uLa+2A6+joqDnX0DX3O3/3GPeysLBAZmYmrly5AnNzcygUCri5uQEANm7ciNdeew3du3eHpaUlFi9erBmvMezt7ZGfn9/o1xO1VgwwRK2Es7MzlixZguPHj6OoqAhffPEFPv/8c7zzzjv1vubmzZt4/PHHMW7cOMydO1dz/OLFi1i9ejUcHBw0f959913NguC6ODk5oaioyKCa7ezsUFhYqHOsoKBAc66ha+53/u4x7rVp0ybIZDIMGDAAHTt2xCuvvILS0lIAwNWrV/HQQw9prjUzM4O3t7dBv9fdioqK4OTk1OjXE7VWDDBErZClpSVGjRqFQYMG4cSJE3VeU1ZWhtjYWISFheG9997TOefu7o4FCxagsLBQ86ekpARnzpyp9z179+7d4Pm6KBQKZGRkIC8vT3MsOTkZVlZW6NKli+aae1swycnJCA4O1nuMe3Xq1Amff/45rly5gri4OOzfv18T9Dp27AilUqm59s6dO5oFw/VpaDHvn3/+iT59+jT4eiKqjQGGqBUoKCjAggULcOrUKVRUVODOnTv47bffcOjQIURFRdW6vrq6GmPHjoWLiwu++OKLWncqvfzyy1izZg1+++03VFdXo7q6GqdPn651+/LdxowZg19++UXnmEqlQnl5uaaNVVlZifLycs2zaCIjI9G1a1e89tprKCkpQWZmJhYtWoRp06ahbdu2ANTrVb744gscPnwYlZWVWLduHS5cuICpU6fqPca9Nm3ahKtXr0IQBNjZ2cHc3Bzm5uYAgClTpuCDDz7AuXPnUFFRgSVLlty3BeTu7o6bN2/qhCgAKCwsxPHjxzFq1KgGX09EdTD1KmIiMr7S0lJh2rRpQpcuXQQbGxvB3t5e6NGjh/Duu+8KKpVKEATdu5Bq7gpq27atzp1IgwcP1oz5888/CxEREYKjo6Pg6Ogo9O3bV9i5c2e9Ndy+fVtwd3cXUlNTNcdq3vPePxs3btRco1QqhaFDhwrW1taCk5OT8P/+3/8TysvLdcZes2aN4O3tLbRt21YIDg4W4uLidM7rM8bdJk+eLHh4eAhWVlaCu7u7MGvWLKGsrEwQBEGorKwU5syZI7i6utZ5F5IgCEJ0dLTwz3/+U/NzVVWV8NRTTwlOTk6Cvb298NVXXwmCIAirV68WYmNj662DiOonEwRBMGF+IqJW5KuvvsK2bdvw008/mboUUfXr1w+DBg3C4sWL9X5NWVkZevTogV9++QUBAQHGK46ohTI3dQFE1HpMmDBB5xbi1sza2lpnLQ0RGYZrYIiIiEhy2EIiIiIiyeEMDBEREUkOAwwRERFJDgMMERERSQ4DDBEREUkOAwwRERFJDgMMERERSQ4DDBEREUkOAwwRERFJDgMMERERSc7/B/Lt9MLd1bMWAAAAAElFTkSuQmCC\n"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "let $w = 200$ and $b = 100$"
+      ],
+      "metadata": {
+        "id": "L0Ym6kf2aevD"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "w = 200\n",
+        "b = 100\n",
+        "tmp_f_wb = compute_model_output(x_train, w, b)\n",
+        "print(f'our new predicted prices: {tmp_f_wb}')"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "ayBBFomwax0y",
+        "outputId": "22f77b18-3768-40c0-9b7f-5226404f2b2c"
+      },
+      "execution_count": 12,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "our new predicted prices: [300. 500.]\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "plt.plot(x_train, tmp_f_wb, c='b',label='Our Prediction')\n",
+        "plt.scatter(x_train, y_train, marker='x', c='r',label='Actual Values')\n",
+        "plt.title('Housing Prices')\n",
+        "plt.ylabel('Price (in 1000s of dollars)')\n",
+        "plt.xlabel('Size (1000 sqft)')\n",
+        "plt.legend()\n",
+        "plt.show()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 460
+        },
+        "id": "lANNnROra9rF",
+        "outputId": "6979ed29-6788-4b4b-a35c-aafe2b965655"
+      },
+      "execution_count": 13,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 640x480 with 1 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjAAAAG7CAYAAADdbq/pAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAYYVJREFUeJzt3Xl4jPf6x/H3JCEECYl9idReJWJJmtIUpWpfW/sSO90oLdpqq7R0UaqO08VR+9oq3bQ91qK1E4pWbZFQ+xKCbPL8/nhO5yeYkSGZySSf13W5TvI898zcGT3mzvf+LhbDMAxERERE3IiHqxMQERERcZQKGBEREXE7KmBERETE7aiAEREREbejAkZERETcjgoYERERcTsqYERERMTtqIARERERt6MCRkRERNyOChiRbGbWrFlYLBYOHTp0272UlBQsFgtjxoxxfmL/Ex0djcViYdasWU5/7aCgICwWCxaLBQ8PD8qUKcNTTz3Fn3/+me7HR0ZGZm6SIpIuXq5OQERylhIlSrBp0ybKly/vktd/8sknGTNmDKmpqRw4cIA333yTiIgI9u3bR9GiRe0+dtmyZfj6+jopUxGxRwWMiDiVt7c34eHhLnv9woULW1+/bt26lCtXjgYNGjBv3jyGDRt2x8ckJibi7e1NzZo1nZmqiNihFpKIsHXrVho3bkz+/PnJly8fjRo1YuvWrWliGjRoQIMGDW577K1tlVOnTtGrVy9KliyJt7c3JUqUoGXLlpw5cwa4cwspMjKS0qVLs2vXLiIiIvDx8aFixYp8+umnt73eqlWrqFmzJnny5KFChQr85z//ITIykqCgoHv62UNDQwGsLbd/ctm0aRN169Ylb968jBgx4o4/K8DRo0fp0aMHxYsXx9vbm3LlyjFkyJA0Mb/88guNGjWiQIEC5MuXjyeffJK9e/emifn555+pW7cufn5+5M+fn8qVKzN27Nh7+plEcgKNwIhkUzdu3CAlJeW2a7fas2cP9evXp2rVqtb5M++++y7169dn8+bN1KhRw6HX7dGjB8eOHeODDz6gTJkynD59mtWrV3Pt2jW7j7t8+TJdu3Zl6NChvPHGG8ycOZPBgwdTuXJlGjZsCMD+/ftp0aIFYWFhLFq0iKSkJMaNG0dcXBweHvf2+9jRo0cBKFiwoPVaXFwcnTt35qWXXmL8+PHkzZvX5mPDwsLw8fFh7NixVKxYkZiYGP773/9aY3744QfatGlDixYtmDdvHgDvvfceERER7NmzhzJlynDkyBFat27NU089xRtvvEHu3Lk5ePAgR44cuaefSSRHMEQkW5k5c6YB2P3z5ptvWuM7dOhg+Pn5GRcvXrRei4uLMwoVKmS0a9fOeq1+/fpG/fr1b3u9smXLGr169bJ+ny9fPmPKlCk28zt69KgBGDNnzrRe69WrlwEYa9assV5LSEgw/P39jf79+1uvdenSxShcuLBx9epV67W///7b8Pb2NsqWLWv/jflfrl27djWSk5ONxMRE4/fffzfq1q1reHh4GDt27EiTy/Lly+/6s/bo0cPIly+fceLECZuvWb58eePxxx9Pcy0uLs4ICAgwhgwZYhiGYXz55ZcGYMTFxd31ZxARk0ZgRLKpZcuWUbp06TTXbty4cdv8k/Xr19OyZcs0IxC+vr60bt2a7777zuHXDQ0N5YMPPsAwDB5//HGqVauGxWK56+N8fHysIy1gzpWpVKkSMTEx1mubN2+mefPm+Pj4WK+VKFGCunXrpnu0YsGCBSxYsMD6fVBQEF9++SW1atWyXsuVKxctW7a863P997//pWXLlpQsWfKO9w8ePMjhw4d59dVX04yG+fj48Mgjj7B+/XoAQkJCyJUrF507d6ZPnz489thjd51QLJLTaQ6MSDZVrVo16tSpk+ZP7dq1b4u7cOECJUqUuO168eLFuXjxosOvu3jxYlq3bs37779PcHAwpUqVYuzYsaSmptp9XKFChW675u3tTUJCgvX7kydP3vGDvVixYunOr1mzZmzbto2dO3dy6tQpjh49Svv27dPEFClSBE9Pz7s+1/nz528rEm/2z7yfvn37kitXrjR/vv/+e86fPw9AhQoV+Pnnn0lNTbXOpwkPD+eXX35J988lktNoBEYkh/P39+fUqVO3XT916lSaoiJPnjxcvnz5trgLFy6k+b5o0aJMmzaNadOmceDAAWbPns2bb75JkSJFGDx48H3lWqJECWtRcLPTp0+n+zn8/f2pU6eO3Zj0jBiBuaLpxIkTNu8HBAQAMGHCBBo3bnzb/dy5c1u/btiwIQ0bNiQxMZFff/2VN954gxYtWhAdHU3hwoXTlY9ITqIRGJEcrn79+qxYsYIrV65Yr125coXvvvsuzaqjsmXL8tdff5GUlGS9tn79+jSPu1XlypUZP348hQoVum3Vzb0IDw9nxYoVaSYEnzx5kl9//fW+n/teNGnShO+//56TJ0/e8X7lypUJCgpi3759t42G1alTh+Dg4Nse4+3tzeOPP86IESO4evWqdZKxiKSlERiRHO7111/n+++/p1GjRowcORKLxcJ7773HtWvXeOONN6xxnTt35vPPP6dPnz5ERkZy9OhRJk2ahJ+fnzUmLi6Oxo0b061bN6pUqUKuXLn45ptvuHjxIk2aNLnvXEePHs1XX33Fk08+yUsvvURiYiLjxo2jWLFi97wK6X689dZbrFixgrp16/Lqq69SoUIFTpw4wU8//cS8efOwWCxMmzaNNm3akJSURMeOHSlcuDCnT5/mt99+IzAwkGHDhvHpp5+yfv16mjdvTpkyZTh37hwTJkygZMmSVKtWzek/l4g70AiMSA4XHBzMunXr8PX1pVevXvTo0YP8+fPzyy+/pFlC3bBhQz799FO2bNlCq1atmDlzJvPmzUsz+TdPnjzUqlWL6dOn89RTT9GuXTs2bdrE/PnzadOmzX3nWrVqVX744QeuXLlCx44dGTVqFM899xy1a9dOU0g5S1BQEJs3byY8PJxXXnmFZs2a8eabb6aZp9O8eXPWr1/P1atX6devH08++SQjRozg1KlTPPLIIwDUqFGDq1ev8sorr9CkSROee+45HnjgAdasWWNzCbdITmcxDMNwdRIiIvcqPj6eChUq0KJFC2bMmOHqdETESdRCEhG38vzzz1O3bl1KlizJ33//zZQpU7h48eJtu9+KSPamAkZE3EpCQgIjR47k9OnT5M6dm7CwMFatWnXHCbEikn2phSQiIiJuR5N4RURExO1kuxZSamrqbTt+WiyWdG9MJSIiIs5nGAa3NoU8PDxsbpGQLQuYq1evujoNERERuU/58uWzWcCohSQiIiJuRwWMiIiIuB0VMCIiIuJ2st0cmDtN1rXXQxMRERHXu9McVnsLcHJEAWNvFrOIiIhkTfYKGH2qi4iIiNtRASMiIiJuJ9u1kO4mNTWV06dPk5KS4upUJIN5eXlRrFgxtQtFRHKAHFfAnD59mgIFCpA/f35XpyIZLD4+ntOnT1OiRAlXpyIiIpksx/2qmpKSouIlm8qfP79G1kREcogcV8CIiIiI+1MBkwUkJSUxcuRIKlSowIMPPkj16tWZPXt2hj1/UFAQlStXJiQkhKpVqzJt2rT7fs69e/cSFBQEwN9//01ERMRdH/PRRx9x6tQp6/effvopH3zwwX3nIiIiOU+OmwNzJ488kjnPu2lT+uIiIyNJTExk9+7d5MuXj+joaJo1a0ZKSgp9+/Z16DVTUlLw8rr9r3Xx4sWEhIRw7NgxgoODiYiIIDg42Hr/nxO872UCbMmSJdmwYcNd4z766CMaNGhA8eLFARg0aJDDryUiIi4UFwc//gidO///tUWLoFkz8PNzaioqYIDNm1332gcPHmT58uXExsaSL18+wBwx+fDDDxk0aBB9+/Zl3bp1DB06lKioKMAc/WjZsiXR0dFER0cTEhLCwIEDWblyJT179mTo0KE2X69s2bJUrlyZv/76i6+//prff/+d+Ph4YmNjWblyJXv37mXcuHFcv34dT09P3nvvPRo2bAjAmDFjmD9/Pr6+vjRr1sz6nP/kcOnSJQA2bdrEyy+/zJUrVzAMg3HjxrF7927+/vtvOnXqRN68eZk1axbLly/n0qVLfPTRR9y4cYNRo0bx448/AtCwYUM+/PBDcufOTWRkJN7e3hw6dIjY2FiqVavGokWLyJ07d8b/hYiIyJ3FxUHTpuaH5pkz8MIL8PHHMGQIhIfDTz85tYhxaQvp5tZGSEgIixcvBswP9bp161KpUiVCQ0PZt2+f9TH27rmjXbt2UbFiRQICAtJcf+SRR4iNjeXs2bN3fY64uDgeeughdu7cabd4Afj999/5888/qVGjBmAWG3PmzGH//v0kJiYyZswYVqxYwY4dO1iwYAFdu3YlMTGRH374gS+//JIdO3awfft2oqOj7/j8Fy5coG3btkyYMIHdu3cTFRVFREQEb7zxBiVLlmTx4sVERUUREhKS5nGff/4527ZtY8eOHURFRXH48GEmT55svR8VFcV3333HH3/8wenTp1m6dOld3xcREckgNxcvYBYtFSqY/wvm9aZNzTgncfkcmH8+0KKioujUqRMAAwcOZMCAAfz111+MHDmSyMhIa7y9ezlVrly56N69u92YTp06WUdqvvjiCypWrAhA8+bNKVasGAA//fQThw4d4rHHHiMkJISnnnoKDw8PYmJiWL16NR07dsTX1xeLxcLAgQPv+DqbNm2icuXK1jkxHh4e+Pv73/VnWLVqlXWkxcvLi/79+7Ny5Urr/Xbt2uHj44OnpydhYWEcPnw4Xe+NiIjcp5uKl1QsbKe2ef3Wf4edXMS4vIC51ZkzZ9i+fbv1A7lDhw7ExsZy6NAhu/fcVc2aNTl48CDnz59Pc33Tpk2UKVOGIkWK4OXlxY0bN6z3EhIS0sT6+Pjcde7KP4Xib7/9xlNPPWW9fvOScsMweOKJJ6wFZVRUFCdOnLAWOzezdz5FRrj1+fPkyWP92tPTU8ulRUSc5ccfYfNmTlOUpvxEPX5lJzXvHLt5sxnvBC6fA9OzZ08MwyAsLIx3332X2NhYSpQoYZ2IarFYCAwMJCYmBj8/P5v3KlSocM85hIdnyI9yTypWrEirVq0YMGAAc+fOxcfHh+joaIYPH87rr78OQLly5Th27Bhnz56lSJEizJ07N1NyefLJJ3nrrbfYs2ePdYLv1q1bCQsLo3HjxowYMYJhw4aRP39+Pv/88zs+R926dTl48CAbNmwgIiKC1NRULl26hL+/P76+vsTZqMwbN27MnDlz6Nq1Kx4eHvznP/+hSZMmmfJzioiIAzp3Zs3G3HSb9ginMDcK7cgSdlILX66kjZ0yJe0E30zk0gJm/fr1BAYGkpyczOjRo+nVqxfjxo1zeh7pXS2UWebMmcPo0aOpXr06uXPnxtPTk5dffpk+ffoA5iqfESNGEBYWRrFixdJMoM1IFSpUYMGCBQwcOJBr166RlJREzZo1WbBgAc2bN2fr1q3UqlXrtkm8NytUqBDLli1j+PDhXLlyBQ8PD8aNG0erVq144YUX6N+/Pz4+PsyaNSvN4wYMGMDhw4epVasWAA0aNLjrfB4REclcN27AuHEw9t/tMW66fpgKDOBzFtIF63h5+fLmxF4nsRiGYdw9LPOdPHmSSpUqcfjwYSpUqMCFCxfw8vLCMAxKlCjBxo0b8fX1tXnvnxGY1NRUrlxJWxEWKFDA2mKJjY2lTJkyTv/5xDn09ysikjFOnoRu3WDtWtsxnzGAAUz//wtTptxzEXO3z+9buWwOzNWrV63LbgEWLlxIzZo1KVq0KLVq1WLevHkALF26lNKlS1OhQgW790RERCRjrFwJISH2i5dSHOdB/kh7ccgQc18YJ3BZC+n06dN06NCBGzduYBgG5cqVY86cOQB89tlnREZGMn78eHx9fZk5c6b1cfbuiYiIyL1LSYExY2D8eLDXn2nOD8ymF4VJuwCF8HBzUzsnyDItpIyiFlLOpr9fEZF7c/w4dO0K9jZW9yKZCbzCMCbhUb5c2qXU97mZndu0kERERCRrWLHCbBnZK14CS6ey/qFneIkP8ZjyERw6ZM55AZfsxOvyZdQiIiLiGsnJ8NprcLdzdVu3hpkzPfD3nAg/Nvr/pdIvvABFi+osJBEREXGOmBizDrG3lUiuXGZx88ILYO4v6nf7Pi9O2vflVmohpUdc3O2zqhctcuqZDyIiIhnl22/NlpG94uWBB+DXX82FRZm8+fo9UQFzN/+cAdGli3nqJpj/26VLhp75cOXKFfLnz0/fvn3TFb9u3Tp++umn+37d6OhoChYseNv1rVu3Urx48du27F+2bJl1l15bgoKCrCdni4hI1pGUBC++CG3awMWLtuM6dICdOyE01Hm5OUoFjD1OPH1z8eLF1K5dm6+//pr4+Pi7xmdUAWNLWFgYRYoU4cdbzrSYMWNGuossERHJOo4ehUcfhY8+sh2TOzf861/w5Zdwh99tsxQVMLbcWrz8I5NO35wxYwYjR47kscceY/HixTelEUe/fv2oVq0aNWrUoE+fPkRFRfHpp58yf/58QkJCGDt27G0jKfHx8WkOROzWrRt16tQhODiYFi1acOrUqbvm1LdvX7744gvr9ydPnmTt2rV0796dSZMmERoaSkhICKGhoWyyMQ7ZoEEDli9fbv3+qaeesh4jcOXKFfr3709YWBjBwcEMGDCApKQkAN5++20efPBBQkJCCAkJ4dixY+l5G0VE5A6+/hpq1oRt22zHVKhgfqQ9+2zWbBndSgWMLf87fTNd7vP0zf379xMbG8uTTz5J3759mTFjhvXe0KFDyZ07N3v27GH37t289957hISEMGjQILp160ZUVBRvvPHGXV/jo48+Yvv27ezZs4eIiAjGjBlz18d0796dlStXcvbsWQBmz55Ny5YtCQgIoEePHmzbto2oqCimTp1K7969Hf65hw8fTkREBFu3bmX37t2kpqYyZcoULl68yMSJE9m5c6f1BO1ixYo5/PwiIjldQgI8/7zZErL3e3bnzrBjh1nkuAutQrKlc2c4c+b/20X23OfpmzNmzKBnz554enrSvHlzBg4cyB9//MGDDz7I999/z5YtW6wb+RQpUuSeXmPBggXMnTuXhIQEEhISKFy48F0fU7hwYZo3b87cuXMZNmwYM2fOZOrUqQDs2rWLd955h/Pnz+Pl5cWBAwe4fv06efPmTXdOy5cvZ9OmTUyaNAmA69ev4+npia+vLxUrVqR79+40adKEFi1aULp06Xv6uUVEcqpDh6BjR9i1y3ZMnjzmtM5+/dxj1OVmKmDseeEF82/21rbRze7z9M3k5GTmzp1Lrly5WLBgAQDXrl1jxowZTJw4Md3P4+XlxY0bN6zfJyQkWL/euHEjH3/8MZs2baJo0aJ8++236Rq1AbON9NJLLxEWFkZCQgKNGzcmKSmJ9u3bs3btWkJDQ7l8+TJ+fn4kJibeVsDYy8swDJYuXUqlSpVue93Nmzfz22+/sW7dOsLDw1m4cCERERHpfj9ERHKyxYuhf3+4ZWPbNCpXhiVL4C7rMrIstZDsuVvxAub9f1Yn3YNvv/2WcuXKceLECaKjo4mOjmbz5s3MnTuX5ORkWrduzcSJE0lNTQWwtnN8fX2Ju2k8sHjx4hiGwf79+wGs50oBXLx4kQIFChAQEEBSUhKfffZZuvN74okniIuL48UXX6R37954eHiQkJBAUlISgYGBANZRmTupUKECW7ZsAeDo0aNs3LjReq9t27a899571pVOFy9e5NChQ1y5coXTp08TERHB66+/zqOPPsoue79CiIgIANevw6BBZlPAXvHSowds3+6+xQuogLFt0aL0tY/gvk7fnDFjBt26dUtz7cEHH6RUqVJ89913TJ48mcTERKpXr05ISAivvvoqAO3atSMqKso6idfLy4upU6fSsmVLQkNDSU5Otj5f06ZNqVy5MpUrVyYiIoKQkJB05+fh4UHv3r3ZsWOHdZ6Lr68vb7/9NmFhYdSuXZvcuXPbfPyIESNYu3Yt1atX55VXXuHhhx+23ps8eTJ58+YlJCSE4OBgGjVqRHR0NHFxcbRv357q1asTHBxMcnIyvXr1SnfOIiI50YED5o7+9n5HzZsXvvgCZs+G/Pmdl1tm0GGOtthahXQnLjgDQu5MhzmKSE40b5458nL1qu2YqlXN5dFVqzovL0foMMeM4udnFiXh4Wmvly+f9nsVLyIi4iLXrkHfvmZLyF7x0qePuYQ6qxYv90IFjD23FjFTprj89E0RERGAffvMnXJv2q7rNvnywdy5MGMG+Pg4Lzdn0Cqku/mniPnxxyxx+qaIiORshgGzZpkbzl2/bjsuONhcjVSlitNScyqNwKSHn43TN1W8iIiIE8XHQ69eZkvIXvEycKA5hTO7Fi+QA0dgvLy8iI+PJ7+7T7+W28THx+PlleP+kxaRHGLPHnNjugMHbMcUKACff35fe6u6jRz3r32xYsU4ffo0F+0dwyluycvLS0cOiEi2Yxgwfbq5Y8dNe4HeplYts2VUoYLzcnOlHFfAeHh4UKJECVenISIicleXL5vtoLttNfbcczBxInh7OyevrCDHFTAiIiLuYNcus2V06JDtGD8/c4VRhw7Oyyur0CReERGRLMQwYNo0c6cOe8VLaKhZ5OTE4gVUwIiIiGQZly6Zoy7PPQdJSbbjXnwRNm6EBx5wWmpZjlpIIiIiWcC2bdCpExw9ajumUCFzD5jWrZ2WVpalERgREREXMgz46COoV89+8fLII2bLSMWLSQWMiIiIi1y4AG3bmi2h5GTbcSNGwC+/QNmyTksty1MLSURExAU2bTI3nIuJsR0TEABz5kDz5s7Ly11oBEZERMSJUlPhgw/gscfsFy8RERAVpeLFFhUwIiIiTnLuHLRqZbaEUlLuHGOxwGuvwZo1ULq0c/NzJ2ohiYiIOMGGDdClC5w4YTumaFGYNw+eeMJ5ebkrjcCIiIhkotRUGD8eGja0X7w0bGi2jFS8pI9GYERERDLJmTPQowf897+2YywWePNNGD0aPD2dl5u7UwEjIiKSCdauha5d4dQp2zHFi8OCBeboizjG5S2kmTNnYrFYWL58OQAPP/wwISEhhISEUK1aNSwWC3v27AEgMjKSUqVKWe+//PLLLsxcRETkdjduwFtvQePG9ouXJ54wW0YqXu6NS0dgoqOjmT59OuHh4dZrW7ZssX791Vdf8dZbbxEcHGy99vLLLzN06FBnpikiIpIuJ09C9+7mCiJbPDxg3DgYNcr8Wu6Ny9661NRU+vXrx9SpU/H29r5jzIwZM+jbt6+TMxMREXHcypUQEmK/eClVCtatg1dfVfFyv1z29k2aNIl69epRu3btO96PjY3ll19+oXv37mmuT5kyheDgYFq2bElUVJQTMhUREbEtJcWcgPvkk+akXVuaNTNbRhERTkstW3NJC2nv3r0sXbqU9evX24yZNWsWLVu2pHDhwtZr77zzDiVKlMDDw4Nly5bRrFkzDh48SP78+Z2RtoiISBonTph7u2zYYDvG0xMmTIDhwzXqkpFc8lZu2LCB6OhoKlasSFBQEJs3b2bAgAF88sknABiGwcyZM29rH5UqVQqP//3tt2vXDl9fXw4cOOD0/EVERH780WwZ2SteAgPN+y+/rOIlo7nk7Rw8eDAnT54kOjqa6OhowsPD+fzzzxk8eDAAa9asISUlhSdu2c3n+PHj1q83b97M+fPnqVChglNzFxGRnC05GUaONM8oOnfOdlzr1rBrFzzyiPNyy0my5D4wM2bMoHfv3tbRln9ERkZy+vRpPD09yZs3L19++SV+fn4uylJERHKamBizZfTbb7ZjcuWC99+HIUPMTeokc1gMwzBcnURGSk1N5cqVK2muFShQ4LZiSERExBHffQe9esHFi7ZjgoJgyRIIDXVaWtmGo5/f+lQXERGxIynJnIDburX94qV9e7NlpOLFObJkC0lERCQrOHoUOneGrVttx+TODZMmwTPPqGXkTCpgRERE7uDrr6FPH4iLsx1TvrzZMqpVy3l5iUktJBERkZskJsLzz0OHDvaLl06dYOdOFS+uohEYERGR/zl06P8LE1u8veHjj6F/f7WMXEkFjIiICGYrqF8/uGUhTBqVK5txN50xLC6iFpKIiORo16/DoEHmyIu94qV7d9i+XcVLVqERGBERybEOHICOHWHPHtsxefPCtGkQGamWUVaiAkZERHKk+fNh4EC4etV2TNWqZsvooYecl5ekj1pIIiKSo1y7Zs516d7dfvHSu7e5/4uKl6xJIzAiIpJj7N9vtoz27bMdky8ffPIJ9OjhvLzEcRqBERGRHGHWLKhTx37xUr26OVFXxUvWpwJGRESytfh48xDG3r3NFUe2DBgAW7ZAlSrOy03unVpIIiKSbf3+u9ky+vNP2zH588P06eaZR+I+NAIjIiLZjmGYRUlYmP3ipWZNc9ddFS/uRwWMiIhkK5cvQ9euZksoIcF23LPPwm+/QcWKzstNMo5aSCIikm3s2mW2jA4dsh3j5wczZpiHNYr70giMiIi4PcOAf/8bwsPtFy+hoWbLSMWL+1MBIyIibi0uzhx1efZZSEqyHTd0KGzcCOXKOS01yURqIYmIiNvavt0sXo4etR1TsKC5B0ybNs7KSpxBIzAiIuJ2DAOmTIG6de0XL+HhEBWl4iU7UgEjIiJu5cIFaNfObAklJ9uOe/llWL8eypZ1WmriRGohiYiI29i8GTp1gpgY2zEBATB7NrRo4by8xPk0AiMiIlleaipMnAgREfaLl0cfNVtGKl6yPxUwIiKSpZ07B61bmy2hlJQ7x1gs8OqrsHYtlC7t3PzENdRCEhGRLGvjRujSBY4ftx1TpAjMmwdNmjgvL3E9jcCIiEiWk5oKEyZAgwb2i5cGDWD3bhUvOZFGYEREJEs5cwZ69ID//td2jMUCb7wBr78Onp7Oy02yDhUwIiKSZaxbZx7EePKk7ZjixWH+fHj8caelJVmQWkgiIuJyN27A2LHQqJH94qVxY3OVkYoX0QiMiIi41KlT0K0brFljO8bDwyxwXnnF/FpEBYyIiLjMqlVm8XLmjO2YkiVh4UJ47DHn5SVZn+pYERFxupQUcwJukyb2i5emTc2WkYoXuZXLC5iZM2disVhYvnw5AA0aNOCBBx4gJCSEkJAQJk+ebI09c+YMTZs2pWLFilSrVo3169e7KGsREblXJ06Yc13efts8lPFOPD3hvffghx/MfV5EbuXSFlJ0dDTTp08nPDw8zfXJkyfTtm3b2+JHjRpFeHg4P/30E9u2baNdu3YcPXqUXLlyOSljERG5Hz/9ZC6RPnfOdkyZMrBokXnStIgtLhuBSU1NpV+/fkydOhVvb+90PWbJkiUMGjQIgNDQUEqWLMkvv/ySmWmKiEgGSE6GUaOgWTP7xUurVmbLSMWL3I3LCphJkyZRr149ateufdu9UaNGUb16dTp16sSRI0cAOH/+PMnJyRQvXtwaFxQURIy9U71ERMTlYmPNHXPfe892TK5cMGkSfPMN+Ps7LTVxYw63kFJTU/nzzz+5cOEC/v7+VKlSBQ8H17Tt3buXpUuX3nEOy9y5cylTpgyGYTBt2jRatmzJ/v37HU1TRESygO++g8hIuHDBdkxQECxeDGFhzspKsoN0Vx47d+6ke/fu+Pv7U61aNR577DGqVatGoUKF6NatGzt37kz3i27YsIHo6GgqVqxIUFAQmzdvZsCAAXzyySeUKVMGAIvFwnPPPceRI0c4f/48AQEBeHl5cerUKevzREdHExgY6MCPKyIizpCUBMOHm6dI2yte2reHXbtUvIjj0lXA9O7dm1atWlGqVCmWLVvG2bNnSUpK4uzZs3zzzTeUKVOGVq1a0bt373S96ODBgzl58iTR0dFER0cTHh7O559/Tv/+/Tl9+rQ1bunSpRQrVoyAgAAAnn76aT799FMAtm3bxokTJ6hfv76jP7OIiGSi6GiIiDBbQrbkzg1Tp8JXX0HBgs7KTLKTdLWQqlevzmeffUbu3LnTXA8ICKBBgwY0aNCAsWPHMm3atPtKJjExkRYtWpCYmIiHhweFCxfm22+/td5/77336NGjBxUrViR37tzMmzdPK5BERLKQZcugTx+4dMl2TPnyZsvoDlMgRdLNYhi2VuG7p9TUVK5cuZLmWoECBRyepyMiIumXmAgvv2yOqtjTsSNMnw6+vs7JS9yHo5/fDk/iPXjwIAULFqRIkSJcvXqVd999Fy8vL0aOHEmePHnuLWsREXFbhw9Dp06wY4ftGG9vmDIFBgwAi8V5uUn25fCwRNeuXTn5v6NCR48ezbJly1i2bBnDhw/P8ORERCRrW7IEata0X7xUqgRbtsDAgSpeJOM43ELy9/fn3LlzeHh4EBgYyLp168ifPz81a9bkxIkTmZVnuqmFJCKS+RIS4MUX4X/rKmzq1g0++QQKFHBOXuK+Mr2FZBgGFouFI0eO4OHhQbly5QC4fPnyPaQrIiLu5q+/zLksu3fbjsmbF/71L+jdW6MukjkcLmBq1KjBO++8Q0xMDE2aNAHgxIkT+GpGlohItjd/vtkKunrVdsyDD8KXX8JDDzkvL8l5HC5gPv74Y5555hm8vb2ZNWsWAKtWreKJJ57I6NxERCSLuHYNXngBZsywH9e7t7kSKV8+5+QlOZdDc2BSUlL4+uuvad26dZZdcaQ5MCIiGeuPP8yW0d69tmN8fMz5MD16OC8vyV4c/fx2eBJvgQIFbnuBrEQFjIhIxpk9G555xhyBsaV6dXM1UpUqzstLsh9HP78d/lQPDg7mwIED95adiIi4hfh46NXLPIjRXvHSv7+5RFrFizibw3Ngnn76adq1a8ewYcMICgpKUxk9/vjjGZqciIg43++/my2jP/+0HZM/P3z+OXTp4ry8RG7mcAvJZi/KYuHGjRsZktT9UAtJROTeGIY5Sff55819XmwJCTFbRhUrOi01yQEyvYWUmpp6xz9ZoXgREZF7c+WKuelc//72i5dnnoFNm1S8iOs53EISEZHsJSrKbBkdPGg7xtfXHJ156imnpSVi1z0VMH/88Qdr1qzhzJkz3NyBGjt2bIYlJiIimcswzKXPL75oniZtS506sHgx/G/jdZEsweEC5quvvqJr165UrVqV/fv3U7VqVfbt28ejjz6aGfmJiEgmiIsz20Vffmk/buhQePdd8zRpkazE4QLm7bff5rPPPqN3794UKlSIqKgopk6dytmzZzMjPxERyWDbt0OnTnDkiO2YggVh1ixo08ZZWYk4xuFVSL6+vly8eBFPT08KFizIpUuXSEpKoly5chw/fjyz8kw3rUISEbkzwzC3+X/pJUhOth0XHg6LFkHZss7LTSTTVyH5+PiQlJQEgL+/PydOnCAlJYW4uLh7SFdERJzh4kVo3x6GDLFfvLz0Eqxfr+JFsj6HW0ihoaH8/PPPtG3blsaNG9O1a1d8fHyoVatWZuQnIiL3acsWs2V07JjtmIAA89iAFi2cl5fI/XB4BGb69OmEhoYC8P7771OlShUKFizIF198keHJiYjIvUtNhQ8/hEcftV+81KtnLqVW8SLuxOE5MFmd5sCIiMD58+ZZRj/8YD/ulVdg7Fjw0q5g4mKOfn6n6z/ZNWvWpOvFdRaSiIjr/fordO4M9tZVFCkCc+fCk086Ly+RjJSuEZj0jF7oLCQREddKTYX334fRo8HeP8cNGsD8+VCypNNSE7mrTBmBSU1Nvf/MREQk05w5Az17ws8/246xWOD11+GNN8DT03m5iWQGdT1FRNzcL79Aly5w8qTtmGLFYMECUKdfsot0FTBvvPFGup5MZyGJiDjPjRswfjyMGWO2j2xp3BjmzTOLGJHsIl0FzIYNG+4aY7FY7jsZERFJn1OnoHt3WL3adoyHB7z1lrnSSC0jyW60jFpExM2sXg3dusHp07ZjSpY0W0b16zsvL5H7kelHCfzjzJkzbN++nTNnztzrU4iIiANSUswJuE88Yb94adrU3JhOxYtkZw4XMJcvX6Zdu3YUL16csLAwSpQoQbt27XQWkohIJvr7b2jUCMaNMw9lvBNPT3j3XXPzuiJFnJufiLM5XMCMGDGCixcvsnPnTi5fvsyOHTuIi4tj5MiRmZGfiEiO99NPUKOGeciiLaVLm6uRRo40576IZHcOz4EJDAxk27ZtFLtpOvupU6cIDQ0lNjY2wxN0lObAiEh2kZJi7tvy7rv241q2hFmzzAMZRdxVpmxkd7Pr169TsGDBNNcKFizI9evXHX0qERGxITbW3Nvl119tx3h5wXvvwYsvmpvUieQkDg9LhIaG8vrrr1t3501NTWXMmDHUqVPnnhKYOXMmFouF5cuXA9C7d28qVapEjRo1qFevHtu2bbPGRkZGUqpUKUJCQggJCeHll1++p9cUEcnKvv8eQkLsFy9ly8LGjTBsmIoXyZkcHoGZNGkSjRs3Zvbs2ZQtW5aYmBi8vLxYuXKlwy8eHR3N9OnTCQ8Pt15r164d06dPx8vLi++//56nn36a6Oho6/2XX36ZoUOHOvxaIiJZXVISvPoqfPih/bh27WDGDChUyDl5iWRFDhcwVapU4c8//+S7777j+PHjlClThhYtWlCgQAGHnic1NZV+/foxdepUhg8fbr3eunVr69fh4eGcOHGClJQUvHTWu4hkY9HR5gnSW7bYjsmdGyZOhOee06iLyD1VBfnz56dLly739cKTJk2iXr161K5d22bMlClTaN68eZriZcqUKXzxxRcEBgby9ttvExIScl95iIi42vLl0Ls3XLpkO6ZcOViyBOz8kymSo6SrgEnvGUfpPTNp7969LF26lPV21gTOmzePJUuWpIl55513KFGiBB4eHixbtoxmzZpx8OBB8ufPn67XFRHJShITYcQI+Phj+3EdO8Lnn4Ofn3PyEnEH6VpGHRERkeb7LVu2UKhQIQIDA4mNjeXChQuEh4fbLUhu9sknnzB27Fi8vb0Bcxm2r68vb731FoMHD2bx4sWMHj2a1atXExgYaPN5KleuzIIFC9KM4mgZtYi4g8OHoVMn2LHDdoy3N3z0EQwcqJaRZH+Ofn47vA/Mq6++ipeXF2PGjMHDw4PU1FTeeustUlJSeOedd+4p6QYNGjB06FDatm3LkiVLeO2111i1ahVly5ZNE3f8+HFKly4NwObNm2nZsiWHDx/G76ZfS1TAiEhW9+WX0K8fXL5sO6ZiRbNlpC655BSZXsAUK1aM48ePkytXLuu1pKQkypQpw2l7h3PYcXMBkytXLooXL07ATTsyrV69moCAABo3bszp06fx9PQkb968jB8/noYNG6Z5LhUwIpJVJSSYy54/+cR+XNeu8Omn4ODaCBG3lukb2Xl4eHDkyBEqV65svXb06FEs9zG+uW7dOuvXycnJNuNWrVp1z68hIuJKf/1lzmXZvdt2TN68MHUq9OmjlpHI3ThcwPTo0YNmzZrx0ksvERQURHR0NB9++CE9evTIjPxERNzeggXmPJb4eNsxDz5otoyqVXNeXiLuzOECZsKECRQsWJCPPvrIOielT58+OsxRROQW167BkCHwn//Yj4uMhH/9C/Llc0paItmCw3NgsjrNgRGRrOCPP8yW0d69tmN8fMz5MD17Oi8vkazK0c9vfaqLiGSw2bOhTh37xUu1arB9u4oXkXulAkZEJINcvWq2gyIjzfaRLf37w9at5rwXEbk3OmBIRCQD7N1rtoz++MN2TP788Nln5jJpEbk/6RqB2bdvX2bnISLilgzDnKQbGmq/eKlRw9x1V8WLSMZIVwHzyCOPWL+uXr16piUjIuJOrlyB7t3NllBCgu24Z56BzZuhUiXn5SaS3aWrgMmbNy+nTp0CIDo6OjPzERFxC1FR5kTdBQtsx/j6mnu7TJsGefI4LTWRHCFdc2C6du1KUFAQRYsW5fr16zYPWIyJicnQ5EREshrDMLf5f/FF8zRpW2rXhsWLoXx55+UmkpOkex+YzZs3c+jQIfr378+nn356x5hevXplaHL3QvvAiEhmiYuDAQPMURV7hgyB994zT5MWkfTJtLOQwsPDCQ8P59ChQ1miUBERcaYdO8xVRkeO2I4pWBBmzoS2bZ2VlUjOdU878RqGwbZt24iJiSEwMJDQ0ND7OswxI2kERkQykmGY2/y/9BIkJdmOe/hhWLQIgoKclppItpLpp1GfPHmS1q1bs3PnTgoVKsTFixepVasW33zzDSVLlry3rEVEsqCLF6FvX1i2zH7c8OEwfjzkzu2cvETkHnbiffHFFylXrhxnz57l3LlznD17lgoVKvDiiy9mRn4iIi6xZQvUqmW/ePH3h+++g4kTVbyIOJvDLaQSJUpw4MABfH19rdfi4uKoXLmydam1K6mFJCL3wzBg0iQYNQpSUmzH1asHCxdCmTLOy00kO8v0wxwNw7jtyTw8PMhmh1qLSA50/jy0bm3Od7FXvLzyCqxdq+JFxJUcLmDq16/PoEGDuHz5MmCOvjzzzDPUr18/w5MTEXGWX3+FmjXh++9txxQuDD/9ZM53yZXLebmJyO0cLmAmT57Mvn378Pf3p2jRohQuXJi9e/cyefLkzMhPRCRTpabCu+9C/foQG2s7rn592L0bnnzSebmJiG33tIw6NTWVrVu3EhsbS5kyZQgLC8syc0w0B0ZE0uvsWejZ0xxVscVigddfN/94ObxuU0TSy9HP73sqYLIyFTAikh7r10OXLvD337ZjihWD+fOhUSPn5SWSU2X6JF4REXd24wa8/TY0bGi/eGnUyDywUcWLSNakAVERyTFOn4Zu3WD1atsxHh4wZgy8+ip4ejotNRFxkAoYEckRVq82i5fTp23HlCwJCxaYE3ZFJGtTC0lEsrUbN+DNN+GJJ+wXL08+abaMVLyIuAeHC5hp06YRFRUFwM6dOylTpgwPPPAAO3bsyOjcRETuy99/Q+PGMHasucPunXh6woQJsGIFFCni3PxE5N45vAqpXLlybN68maJFi9KiRQuqVKlC/vz5Wb9+PWvXrs2sPNNNq5BEBODnn6FHD3OptC2lS5snSNer57y8ROTOMn0ZtZ+fH3FxcaSkpFC4cGH+/vtvcufOTbFixTh//vy9Z55BVMCI5GwpKeaeLe++az+uZUuYNQsCApySlojchaOf3w5P4vXx8eHixYvs3buXKlWq4OPjQ3JyMsnJyfeWsYhIBomNNfd2+fVX2zFeXmZxM2yYuUmdiLgnhwuYdu3a0bhxY+Lj4xk4cCAAe/bsoWzZshmenIhIev3wg7mr7oULtmPKljVbRuHhzstLRDKHwy2k5ORkZs+eTe7cuenevTseHh6sXbuWM2fO0KlTp8zKM93UQhLJWZKTzT1bJk60H9e2LXzxBRQq5JS0RMRBOkpABYxIjnHsGHTqBFu22I7Jlcssbp5/Xi0jkawsU+fA7Ny5k08++YRdu3Zx+fJlfH19qVmzJoMHD6ZWrVr3nrWIiIOWL4feveHSJdsx5crB4sVQp46zshIRZ0n3sMSyZct49NFHOX/+PB06dGDYsGF06NCBCxcuEBERwfLly+8pgZkzZ2KxWKyPP3PmDE2bNqVixYpUq1aN9evXW2Pt3RORnCEpCYYOhXbt7BcvTz8NO3eqeBHJrtI9AjN69GjmzZtH+/btb7u3bNkyXn31Vdq2bevQi0dHRzN9+nTCb5pRN2rUKMLDw/npp5/Ytm0b7dq14+jRo+TKlcvuPRHJ/o4cMVtG27fbjvH2hsmTYdAgtYxEsrN0j8BER0fTpk2bO95r1aoV0dHRDr1wamoq/fr1Y+rUqXh7e1uvL1myhEGDBgEQGhpKyZIl+eWXX+56T0Syt6++gpo17RcvFSvC5s0weLCKF5HsLt0FTGBgIN99990d7/3www8OL6OeNGkS9erVo3bt2tZr58+fJzk5meLFi1uvBQUFERMTY/eeiGRfCQnw7LNmS+jyZdtxXbvCjh0QEuK01ETEhdLdQho3bhxdunShefPmhIWFUbBgQS5dusS2bdtYsWIFc+fOTfeL7t27l6VLl2oOi4jYdfAgdOxoHrJoS548MHUq9O2rUReRnCTdBcxTTz1FmTJl+Oyzz1i8eLF1FVJISAhr167l4YcfTveLbtiwgejoaCpWrAjAqVOnGDBgAG+99RZeXl6cOnXKOtISHR1NYGAgAQEBNu+JSPazcCEMGADx8bZjqlSBJUugenXn5SUiWUOW2AemQYMGDB06lLZt2xIZGUlQUBBjxoxh27ZttG3blujoaHLlymX33j+0D4yIe7t+HYYMgenT7cf16gXTpkG+fM7JS0QyV6afhXT8+HGioqK4fPkyfn5+hISEUKpUqXvL9g7ee+89evToQcWKFcmdOzfz5s2zFij27omI+/vzT3Ouy969tmN8fODf/zYLGBHJudI9AhMXF0evXr349ttvyZ07t3UOTHJyMq1bt2b27Nn4+vpmdr53pREYEfc0Z465eujaNdsx1aqZG9NVreq8vETEORz9/E73p/pzzz3H1atXiYqKIiEhgVOnTpGQkMCuXbu4du0azz333P1lLiI50tWr5o66vXrZL1769TOPDFDxIiLgwAiMv78/hw4dwt/f/7Z7586do2LFily8eDHDE3SURmBE3Me+feYqo/37bcfkzw+ffWYukxaR7CvTRmBSU1Ox2FijaLFYyAJzgUXETRgGzJgBoaH2i5caNcy9XVS8iMit0l3AtGjRgk6dOrH3ltl1e/fupVu3brRs2TLDkxOR7OfKFejRw2wJXb9uO27wYHNX3UqVnJebiLiPdBcw06ZNI1euXAQHB+Pj40OJEiXw8fGhRo0a5MqVi3/961+ZmaeIZAO7d5uHK86fbzumQAFzou6//21uUicicicO7wNz7NgxoqKiuHLlinUju6y0mZzmwIhkPYZhzmMZOhQSE23H1a5tFi/lyzstNRHJIhz9/M4SG9llJBUwIlnL5cvQv7+5Y649zz8PH3xgniYtIjlPpm5kt3PnTj755BN27dplPUqgZs2aDB48mFq1at171iKSLe3YAZ06weHDtmMKFoQvvoB27ZyWlohkA+kelli2bBmPPvoo58+fp0OHDgwbNowOHTpw4cIFIiIiWL58eSamKSLuxDDMAxbr1rVfvISFwa5dKl5ExHHpbiE99NBDjBs3jvbt2992b9myZbz22mvst7ce0knUQhJxrUuXzJOhv/7aftzw4TB+POTO7ZS0RCSLy7Q5MPny5ePy5ct4enredi8lJQVfX1+u2dtG00lUwIi4ztatZssoOtp2jL8/zJoFrVo5KysRcQeZtpFdYGAg33333R3v/fDDD5QtW9aBNEUkOzEMmDQJ6tWzX7zUrQtRUSpeROT+pXsS77hx4+jSpQvNmzcnLCzMepjjtm3bWLFiBXPnzs3MPEUki7pwASIjwcbvN1ajRsHYsaAD5EUkI6S7gHnqqacoU6YMn332GYsXL7auQgoJCWHt2rU8/PDDmZmniGRBv/0GnTtDbKztmMKFYe5caNrUeXmJSPanfWBExGGpqeaeLa+9Bjdu2I577DFYsABKlXJebiLinjJtDoyICMDZs9CypdkSslW8WCwwejSsXq3iRUQyh0Mb2dmSmJiIj48PN+z9KiYibm/9eujSBf7+23ZMsWIwbx40buy8vEQk58mwEZhs1okSkZvcuAFvvw0NG9ovXh5/3FxlpOJFRDJbukdgHnvsMZv3DMPAYrFkSEIikrWcPg3du8OqVbZjPDxgzBh49VW4w1ZRIiIZLt0FzJYtWxgwYACFCxe+7V5ycjK//fZbhiYmIq63Zg106wanTtmOKVHCnKjboIHT0hIRSX8B89BDD9G0aVNatGhx272EhATGjx+foYmJiOvcuGHu2TJunLlJnS1NmphLpIsWdV5uIiLgQAHTokULzp07d+cn8fKiV69eGZaUiLjO33+boy7r1tmO8fQ058SMGGG2j0REnE37wIiI1X//a853OXvWdkzp0rBwITz6qPPyEpHsT/vAiIjDUlLMCbhPPmm/eGnRAnbtUvEiIq6XIfvAiIj7On7c3Ntl40bbMV5eMGECDBumlpGIZA0qYERysBUroGdPOH/edkzZsrBoEYSHOy8vEZG70e9SIjlQcrI5AbdFC/vFS5s2ZstIxYuIZDUagRHJYY4dM0+Q3rzZdkyuXOZhjS+8YJ5rJCKS1dxTAXPkyBF27Nhx22zhPn36ZEhSIpI5vvkGeveGixdtx5QrB4sXQ506zstLRMRRDi+j/vTTT3nuuefw9/cnX758//9EFgtHjhzJ8AQdpWXUIrdLSjJbRlOm2I976in4z3/Az885eYmI/MPRz2+HC5iyZcsyefJk2rdvf+9ZZiIVMCJpHTkCnTrB9u22Y7y9YfJkGDRILSMRcY1ML2AKFizIpUuX7jnBzKYCRuT/LV0KffrA5cu2YypWhCVLICTEaWmJiNwm0zeya9GiBb/88su9ZSciTpGQAM89Z7aE7BUvXbrAjh0qXkTE/Tg8ibdIkSK0bduWDh06ULJkyTT3xo4dm+7nadKkCadOncLDw4MCBQrw8ccfExgYSKNGjawx165d48iRI5w5cwZ/f38aNGjAsWPH8Ptfg75Xr168+OKLjv4IItnawYNmy2jXLtsxefLAxx9Dv35qGYmIe3K4gNm9ezchISEcPnyYw4cPW69bHPxXcMmSJRQsWBCAZcuWERkZye7du4mKirLGTJw4kV9++QV/f3/rtcmTJ9O2bVtH0xbJERYtgv79IT7edkyVKmbLqHp15+UlIpLRHC5g1q5dmyEv/E/xAhAXF3fHAmjGjBlMmDAhQ15PJDu7fh2GDoXPP7cf17MnTJsG+fM7JS0RkUzj0pmtPXv2pEyZMrz++uvMnTs3zb3ffvuNixcv0rJlyzTXR40aRfXq1enUqVOWWLYt4mp//gkPP2y/ePHxgZkzYfZsFS8ikj2kaxVS06ZN+emnnwCIiIiw2S5av379PSUxe/ZsFi9ezIoVK6zX+vbtS0BAAO+//771WmxsLGXKlMEwDKZNm8a///1v9u/fn+a5tApJcpK5c2HwYLh61XbMQw+ZLaOqVZ2Xl4iIozJlGfWECRN45ZVXAHjrrbdsxr355puO5JpG3rx5OX78OAEBAcTHx1OiRAm2bdtGlSpVbD4mT548nDhxgoCAAOs1FTCSE1y9Cs8/b46q2NO3rzlZ18fHOXmJiNwrRz+/0zUH5p/iBe6vSPnHpUuXuHbtmnUV0/LlywkICLBO1l28eDE1atRIU7ykpKRw/vx5ihUrBsDSpUspVqxYmuJFJCfYtw86doRbBh/TyJcPPvsMunVzXl4iIs7kksMc4+LiePrpp7l+/ToeHh4UKVKE77//3tqamjFjBv3790/zmMTERFq0aEFiYiIeHh4ULlyYb7/91hXpi7iEYZgjLs89Z07ataVGDbNlVKmS83ITEXG2dLWQQkJCGDduHC1btrzj/BfDMPj2228ZM2YMu+xtPuEEaiFJdhQfb851mTfPftygQTBpEuTN65y8REQySqbMgfn111954YUXOH36NI0aNaJatWr4+fkRFxfHvn37WL16NUWLFuXjjz+mXr16GfOT3CMVMJLd7N5ttoz++st2TIEC5iGMHTs6Ly8RkYyUqWchrV27lq+//prt27dz4cIF/P39qV27Nu3bt+fxxx+/v8wziAoYyS4Mw1waPWQIJCbajqtVCxYvhgoVnJebiEhGy/TDHLM6FTCSHVy+DAMGmIWJPc8/Dx98YJ4mLSLizjJlFZKIOM/OnWYr6KaTOm7j5wdffAHt2zsvLxGRrETDEiJZhGHAv/4Fjzxiv3gJCzMPalTxIiI5mQoYkSzg0iV46imzJZSUZDtu2DDYsAEeeMBpqYmIZElqIYm42Nat0KkTREfbjilUyDzHqFUrp6UlIpKlaQRGxEUMAyZPhkcftV+81K0LUVEqXkREbuZwAZOamsqECROoWLEifn5+APz8889Mnz49w5MTya4uXIC2bc2WUHKy7biRI2HdOggMdFZmIiLuweECZsyYMSxZsoS33nrLuitvhQoV+OSTTzI8OZHsaNMmCAkBeydhFC4MK1bAu+9CrlxOS01ExG04vA/MAw88wPr16ylTpgz+/v5cuHCB1NRUChcuzIULFzIrz3TTPjCSVaWmwsSJ8OqrcOOG7biICFi4EEqVcl5uIiKu5ujnt8Of6leuXKF06dJprt24cQMvL80HFrHl7Flo2dJsCdkqXiwWGD0a1qxR8SIicjcOFzDVq1fnq6++SnPtm2++oWbNmhmWlEh2smGD2TL68UfbMUWLws8/w7hxoN8FRETuzuF/Kt99910aN27M8uXLSUhIoF+/fnz11VesXLkyM/ITcVupqTBhArzxhvm1LQ0bwvz5UKKE83ITEXF3Do/APPzww2zfvp3ChQvToEEDUlNTWbVqFaGhoZmRn4hbOn0amjY1W0K2ihcPD3jrLVi5UsWLiIijdJijSAZbswa6dYNTp2zHlCgBCxZAgwZOS0tEJEvL9Em8H3zwAVu2bElzbfPmzUycONHRpxLJVm7cgDFjoHFj+8VLkybmxnQqXkRE7p3DIzCBgYHs2bOHggULWq9dvHiRGjVqEBMTk9H5OUwjMOIKJ0+aoy5r19qO8fQ0J+mOHGm2j0RE5P85+vnt8CTeS5cupSleAAoVKsTFixcdfSqRbGHlSujeHc6csR1TqhQsWmQeGyAiIvfP4d8Dy5Qpw44dO9Jc27FjB6W0cYXkMCkp5iTdJ5+0X7w0b262jFS8iIhkHIcLmL59+9KlSxeWLVvGvn37WLZsGd26daNfv36ZkZ9IlnT8ODz+OLzzjnko4514ecEHH8B335lHA4iISMZxuIU0ZMgQLly4QK9evYiPjyd//vw8//zzDBs2LDPyE8lyVqyAnj3h/HnbMYGBZsvokUecl5eISE5yX8uoz507R+Es9qulJvFKZklOhtdeM0dV7GndGmbOBH9/5+QlIpIdZPok3ptlteJFJLPExEDnzuZJ0rbkymUWNy+8YJ5rJCIimSddBcyDDz7IH3/8AZiTeC02/nXOCsuoRTLat99CZCTYW2j3wAOweDFoQ2oREedIVwHz+uuvW79+++23My0ZkawkKcncs+Wjj+zHdegA//kP3LK7gIiIZKJ0FTBdu3YFICUlhbx589KmTRu8vb0zNTERVzp6FDp1gm3bbMfkzg2TJ8PgwWoZiYg4m8OTeAsUKHDbJJusRJN45X59/TX06QNxcbZjKlSAJUugZk3n5SUikp1l+llIwcHBHDhw4N6yE8nCEhLg+efNlpC94qVzZ9ixQ8WLiIgrObwK6emnn6Zdu3YMGzaMoKCgNJXR448/nqHJiTjLoUPQsSPs2mU7Jk8e+Phj6NdPLSMREVdzuIVkayjHYrFw48aNDEnqfqiFJI5avBj69wd7ndHKlc2WUXCw8/ISEclJMr2FlJqaesc/WaF4EXHE9eswcKDZErJXvPToAdu3q3gREclKHGohrV+/nh07dhAWFka9evUyKyeRTHfggNky2rPHdkzevDBtmrkHjFpGIiJZS7pHYL744gsaNGjA+PHjqV+/PvPmzbvvF2/SpAnBwcGEhIQQERHBrv9NQAgKCqJy5cqEhIQQEhLC4sWLrY85ePAgdevWpVKlSoSGhrJv3777zkNylnnzoHZt+8VL1armqEvv3ipeRESyJCOdqlevbsybN88wDMOYM2eOUadOnfQ+1KaLFy9av/7666+N4OBgwzAMo2zZssauXbvu+JiGDRsaM2fONAzDML788svb8rhx44Zx6dKlNH9u3Lhx37mK+7t61TB69zYM8/xo23/69DFjRUTEeRz9/E73CExMTIx1Q7uuXbty7Nix+y6eCt60dWlcXJzNIwr+cebMGbZv30737t0B6NChA7GxsRw6dOi+c5Hsbd8+c5v/mTNtx+TLB3PnwowZ4OPjvNxERMRx6Z4Dk5qaai0wPD09SUlJyZAEevbsydq1awFYsWJFmuuGYRAWFsa7775LkSJFiI2NpUSJEnh5mWlbLBYCAwOJiYmhQoUKGZKPZC+GAbNmwbPPmpN2bQkONlcZVa7stNREROQ+pLuASUxM5I033rB+f/369TTfA4wdO9bhBObMmQPA7NmzGTlyJCtWrGD9+vUEBgaSnJzM6NGj6dWrV5riRiQ94uPhmWfMURV7Bg40jwTIm9c5eYmIyP1L9z4wDRo0sNvisVgsrFmz5r6SyZs3L8ePHycgIMB67eTJk1SqVIkrV65w5swZKlSowIULF/Dy8sIwDEqUKMHGjRutIzDaB0bAnKDbsaO52siWAgVg+nTzzCMREXEtRz+/0z0Cs27duvtK7FaXLl3i2rVrlCxZEoDly5cTEBBAnjx5uHTpknV+zMKFC6n5vz3bixYtSq1atZg3bx6RkZEsXbqU0qVLq30kVoZhFiVDhphHA9hSq5a5gZ3+0xERcU8OHyWQUeLi4nj66ae5fv06Hh4eFClShO+//57Tp0/ToUMHbty4gWEYlCtXztpmAvjss8+IjIxk/Pjx+Pr6MtPerEzJUS5fNttBixbZj3vuOZg4EXSguoiI+3L4KIGsTi2knGnXLrNlZG9Bmp+fucKoQwfn5SUiIumT6UcJiGQlhmHulhsebr94CQ01ixwVLyIi2YMKGHFbly7B00+bLaGkJNtxL74IGzfCAw84LTUREclkLpsDI3I/tm0zVw8dPWo7plAhcw+Y1q2dlpaIiDiJRmDErRgGfPQR1Ktnv3h55BGIilLxIiKSXamAEbdx4QK0bWu2hJKTbceNGAG//AKBgU5LTUREnEwtJHELmzZB584QE2M7JiAA5syB5s2dl5eIiLiGRmAkS0tNhQ8+gMces1+8RESYLSMVLyIiOYMKGMmyzp2DVq3MlpCts0MtFnjtNVizBkqXdm5+IiLiOmohSZa0YQN06QInTtiOKVoU5s2DJ55wXl4iIpI1aARGspTUVBg/Hho2tF+8NGxotoxUvIiI5EwagZEs48wZ6N4dVq60HWOxwJtvwujR4OnpvNxERCRrUQEjWcLatdC1K5w6ZTumeHFYsMAcfRERkZxNLSRxqRs34K23oHFj+8XLE0+YLSMVLyIiAhqBERc6edJsGa1ZYzvGwwPGjYNRo8yvRUREQAWMuMjKlWbxcuaM7ZhSpWDhQnOPFxERkZvpd1pxqpQUcwLuk0/aL16aNTNbRipeRETkTjQCI05z4oS5t8uGDbZjPD1hwgQYPlwtIxERsU0FjDjFjz9Cz57m7rq2BAbCokXmSdIiIiL26HdcyVTJyTBypHlGkb3ipXVr2LVLxYuIiKSPRmAk08TEmCdIb9pkOyZXLnj/fRgyxNykTkREJD1UwEim+PZbiIyEixdtxwQFwZIlEBrqrKxERCS7UAtJMlRSEgwbBm3a2C9e2rc3W0YqXkRE5F5oBEYyzNGjZsto61bbMblzw6RJ8MwzahmJiMi9UwEjGeLrr6FPH4iLsx1TvrzZMqpVy3l5iYhI9qQWktyXxER4/nno0MF+8dKpE+zcqeJFREQyhkZg5J4dOvT/hYkt3t7w8cfQv79aRiIiknFUwMg9WbIE+vWDK1dsx1SubMYFBzsvLxERyRnUQhKHXL8OgwaZIy/2ipfu3WH7dhUvIiKSOTQCI+l24AB07Ah79tiOyZsXpk0z94BRy0hERDKLChhJl3nzzJGXq1dtx1StaraMHnrIeXmJiEjOpBaS2HXtGvTtCz162C9eevc2939R8SIiIs6gERixaf9+s2W0b5/tmHz54JNPzAJHRETEWTQCI3c0axbUqWO/eKle3Zyoq+JFRESczWUFTJMmTQgODiYkJISIiAh27dpFQkICbdu2pVKlStSoUYMnnniCQ4cOWR/ToEEDHnjgAUJCQggJCWHy5MmuSj/bio+HXr3MltD167bjBg6ELVugShXn5SYiIvIPl7WQlixZQsGCBQFYtmwZkZGRbNmyhQEDBtCsWTMsFgv/+te/6NevH+vWrbM+bvLkybRt29YlOWd3v/9utoz+/NN2TIEC8Pnn5plHIiIiruKyEZh/iheAuLg4LBYLefLkoXnz5lj+t/42PDyc6Oho1ySYgxgGTJ8OYWH2i5eaNWHHDhUvIiLiei6dA9OzZ0/KlCnD66+/zty5c2+7P2XKFNq0aZPm2qhRo6hevTqdOnXiyJEjzko127p8Gbp2hQEDICHBdtyzz8Jvv0HFis7LTURExBaLYRiGq5OYPXs2ixcvZsWKFdZr48eP57vvvmP16tX4+PgAEBsbS5kyZTAMg2nTpvHvf/+b/fv3p3mu1NRUrtyyRWyBAgXw8NB85Vvt2mW2jG6aZnQbPz+YMcM8rFFERCSzOPr5nSUKGIC8efNy/PhxAgICmDhxIosWLWLVqlVpWk23ypMnDydOnCAgIMB6TQXM3RmGufT5xRchKcl2XGgoLFoE5co5LzcREcmZHP38dsmn+qVLl/j777+t3y9fvpyAgAD8/f2ZNGkSCxcuZOXKlWmKl5SUFE6fPm39funSpRQrVixN8SJ3Fxdnjro8+6z94mXoUNi4UcWLiIhkTS5ZhRQXF8fTTz/N9evX8fDwoEiRInz//fecOHGC4cOHU65cORo2bAiAt7c3W7ZsITExkRYtWpCYmIiHhweFCxfm22+/dUX6bmvbNvMQxqNHbccULGjuAXPL1CMREZEsJcu0kDKKWki3Mwz4+GN4+WVITrYdFx5utozKlnVebiIiIuAmLSRxngsXoF07syVkr3gZMQLWr1fxIiIi7kFnIWVjmzebLaOYGNsxAQEwZw40b+68vERERO6XRmCyodRUmDgRIiLsFy+PPgpRUSpeRETE/aiAyWbOnYPWrc35Likpd46xWODVV2HtWihd2rn5iYiIZAS1kLKRjRuhSxc4ftx2TJEiMG8eNGnivLxEREQymkZgsoHUVJgwARo0sF+8NGgAu3ereBEREfenERg3d+YM9OgB//2v7RiLBd54A15/HTw9nZebiIhIZlEB48bWrTMPYjx50nZM8eIwfz48/rjT0hIREcl0aiG5oRs3YOxYaNTIfvHSuLG5ykjFi4iIZDcagXEzp05Bt26wZo3tGA8Ps8B55RXzaxERkexGBYwbWbXKLF7OnLEdU7IkLFwIjz3mvLxEREScTb+fu4GUFHMCbpMm9ouXZs3MlpGKFxERye40ApPFnThhTtRdv952jKcnjB8PL72klpGIiOQMKmCysJ9+MpdInztnO6ZMGfME6bp1nZeXiIiIq+n39SwoORlGjTJbQvaKl1atzJaRihcREclpNAKTxcTGQufO8NtvtmNy5YL33oOhQ81N6kRERHIaFTBZyHffQWQkXLhgOyYoCBYvhrAwZ2UlIiKS9aiFlAUkJcHw4eYp0vaKl/btYdcuFS8iIiIagXGxo0fNltHWrbZjcueGDz+EZ59Vy0hERARUwLjUsmXQuzfExdmOKV/ebBnVru28vERERLI6tZBcIDERXnjBbAnZK146dYKdO1W8iIiI3EojME52+LBZmOzYYTvG2xumTIEBA9QyEhERuRMVME60ZAn06wdXrtiOqVTJjKtRw3l5iYiIuBu1kJwgIQEGDzZHXuwVL927myMzKl5ERETs0whMJvvrL+jYEXbvth2TNy/861/mhF61jERERO5OBUwmmj8fBg6Eq1dtxzz4IHz5JTz0kPPyEhERcXdqIWWCa9fMuS7du9svXnr3hm3bVLyIiIg4SiMwGWz/frNltG+f7RgfH/j0U/OkaREREXGcRmAy0KxZEBpqv3ipXt2cqKviRURE5N6pgMkA8fHQq5fZErp2zXbcgAGwZQtUqeK83ERERLIjtZDu0++/my2jP/+0HZM/P0yfbp55JCIiIvdPIzDpFRcHixZZvzUM+M+ArYSFGXaLl5AQ8zgAFS8iIiIZRyMw6REXB02bwubNcOYMV3q/wMAGB1i4M8zuw559FiZOhDx5nJSniIhIDuHSEZgmTZoQHBxMSEgIERER7Nq1C4CDBw9St25dKlWqRGhoKPtumhVr716muLl4AaKGfEHtgKMs3FnZ5kN8fc29Xf71LxUvIiIimcGlBcySJUvYs2cPUVFRDBs2jMjISAAGDhzIgAED+Ouvvxg5cqT1+t3uZbhbipft1CaczRxMfsDmQ+rUgV274KmnMi8tERGRnM6lBUzBggWtX8fFxWGxWDhz5gzbt2+ne/fuAHTo0IHY2FgOHTpk916m+PFHa/ECUJNd1ONXm+FDmx1g40YoVy5z0hERERGTy+fA9OzZk7Vr1wKwYsUKYmNjKVGiBF5eZmoWi4XAwEBiYmLw8/Ozea9ChQoZn1znznDmDAwZAoAnqcynGzXYzRmKWcMKcpFZ/X6lzfSWGZ+DiIiI3Mblq5DmzJlDbGwsb7/9NiNHjnR1Ord74QUoX976bXFOM59uWEgFIJxNRAW2UfEiIiLiRC4vYP7Rq1cv1q5dS+nSpTl58iQpKSkAGIZBTEwMgYGBlClTxua9TPPxx3D4cJpLjVnNaN7mJT5gPY9RNmaDGSciIiJO4bIC5tKlS/z999/W75cvX05AQABFixalVq1azJs3D4ClS5dSunRpKlSoYPdepli0yNo+utVbvMkHjCAXZjHFkCFp9okRERGRzGMxDMNwxQsfO3aMp59+muvXr+Ph4UGRIkWYOHEiISEhHDhwgMjISM6fP4+vry8zZ86kevXqAHbvAaSmpnLlypU0r1WgQAE8PO6hVrtlFZJd4eHw00/g5+f464iIiORwjn5+u6yAySwZWsDAnYuY8uXTtpVUvIiIiNwXRz+/s8wcmCzLz88sTsLDze+nTIFDh8z/BRUvIiIiLqARmPSKizP3hbn5UKNFi6BZMxUvIiIi90ktpMwqYERERCTTqIUkIiIi2Z4KGBEREXE7KmBERETE7aiAEREREbejAkZERETcjgoYERERcTterk4go91pVXhqaqoLMhEREZH0utNntb2dXnJEAXP16lUXZCIiIiL3w14BoxaSiIiIuB0VMCIiIuJ2VMCIiIiI28mWZyHdOhHIYrFgsVhclJGIiIjcjWEYt8158fDwyDmHOYqIiEj2pxaSiIiIuB0VMDa88MILBAUFYbFYiIqKshk3Y8YMKlasSPny5enfvz/JycnOSzIbSM/7vGbNGsLCwqhatSoPPfQQI0aM0N4+Dkrvf89gDuM+/vjjFCxY0Cm5ZSfpfZ9///13GjRowIMPPsiDDz7I119/7bwks4H0vM+pqakMGzaMqlWrEhwcTMOGDTl06JBzE3VzCQkJtG3blkqVKlGjRg2eeOIJm+/h999/T5UqVahYsSLt27fn8uXLmZ6fChgbnnrqKTZu3EjZsmVtxhw9epTXX3+dDRs2cOjQIU6fPs3nn3/uxCzdX3re50KFCrFo0SL279/Pjh07+O2335gzZ44Ts3R/6Xmf/zF58mTKly/vhKyyn/S8z9euXaNNmza8/fbb/PHHH+zdu5eIiAgnZun+0vM+f/vtt/z666/s3r2bPXv20KhRI1599VUnZpk9DBgwgAMHDrB7927atGlDv379bouJj4+nb9++LF++nIMHD1KyZEnGjRuX6bmpgLHhscceo3Tp0nZjvvrqK1q3bk3x4sWxWCwMGjSIhQsXOinD7CE973PNmjUpV64cAHny5CEkJITo6GgnZJd9pOd9Bti3bx/Lly9n1KhRTsgq+0nP+7xgwQLCw8N59NFHAfD09KRIkSLOSC/bSM/7bLFYSExMJCEhAcMwuHz5crr+PyD/L0+ePDRv3ty6CCY8PPyO//b++OOP1KxZkypVqgDwzDPPOOWzMNvtxOtMMTExaX4DCAoKIiYmxoUZZX+nTp3iq6++4vvvv3d1KtlOcnIy/fv3Z8aMGXh6ero6nWxr//79eHt707JlS44fP05wcDAffvihipgM1qpVK9auXUvx4sUpUKAApUqV4pdffnF1Wm5typQptGnT5rbrd/osPHnyJCkpKXh5ZV6ZoREYcRuXL1+mVatWjBgxgjp16rg6nWznrbfeon379jz44IOuTiVbS0lJYdWqVXz22Wfs2rWLUqVKMXjwYFenle1s376dvXv3cuLECf7++28aNWrEoEGDXJ2W2xo/fjyHDh1iwoQJrk7FSgXMfQgMDOTYsWPW76OjowkMDHRhRtnXlStXaNq0KW3atGHYsGGuTidb+uWXX5g6dSpBQUE8+uijXL58maCgIM6ePevq1LKVwMBAGjZsSKlSpbBYLHTv3p3Nmze7Oq1sZ86cOdbJ6B4eHvTq1Yu1a9e6Oi23NHHiRL7++mt+/PFHfHx8brt/p8/CEiVKZOroC6iAuS8dOnTg22+/5dSpUxiGwaeffkrnzp1dnVa2Ex8fT9OmTWnatCmjR492dTrZ1oYNGzh27BjR0dFs3LgRX19foqOj1drIYB07dmTbtm3WVRorVqygRo0aLs4q+ylXrhxr1qwhKSkJMFfJVKtWzcVZuZ9JkyaxcOFCVq5caXNlYtOmTdm5cyd//vknAP/+97+d81loyB0NGDDAKFWqlOHp6WkULVrUKF++vGEYhtG3b1/jm2++scZ9/vnnRrly5Yxy5coZffr0MZKSklyVsltKz/v89ttvG15eXkaNGjWsf95++21Xpu120vvf8z+OHj1q+Pn5OTlL95fe93nOnDnGQw89ZFSvXt1o2rSpERMT46qU3VJ63ueEhASjX79+RpUqVYzq1asbTzzxhHH48GFXpu12YmNjDcAoV66c9d/esLAwwzAM4/XXXzc++eQTa+w333xjVK5c2ShfvrzRpk0b49KlS5men3biFREREbejFpKIiIi4HRUwIiIi4nZUwIiIiIjbUQEjIiIibkcFjIiIiLgdFTAiIiLidlTAiAhgbmSXP39+bty4kWmvsWDBAlq0aJFpz59VREdHExERga+vL3Xr1r1jzNWrVylbtix//fWXk7MTyR5UwIjkEEePHqVLly6ULFmS/PnzU7JkSZo3b87JkycBiIiIID4+PtMOckxISOCll17inXfesV5bvXo1jRo1IiAgAIvFwqFDh257XExMDC1btqRAgQIULlyY5557zrq76j+mTZtGUFAQPj4+1KpVi/Xr1zv8HBlpwoQJFCpUiEuXLvHbb78xa9as205CzpcvH8OGDWP48OGZlodIdqYCRiSHaN68OQUKFGDv3r3Ex8eza9cuOnXqhMViccrrL1y4kNKlSxMSEmK9li9fPnr27MmcOXPu+JjU1FRatmyJv78/J06cYMeOHaxfv56XX37ZGvPll1/y6quvMnv2bC5dukTfvn1p3rw5sbGx6X6OjHb48GGCg4Px8LD/T2zPnj1ZtWqVRmFE7kWm7/UrIi537tw5AzB27NhhM2bt2rUGYCQnJxuGYRjFihUz8uXLZ/3j5eVl1K9f3xr/ww8/GGFhYUbBggWNChUqGFOmTLGbQ4sWLYzRo0ff8d7Ro0cNwDh48GCa6+vWrTO8vLyMs2fPWq8tX77c8PHxMa5fv24YhmE0aNDAGDp0aJrHhYSEGGPHjk33c9wqKirKeOyxxww/Pz+jYMGCRq1atYw///zTMAzDSE5ONl5++WWjWLFiRuHChY1Ro0YZ9erVM958803DMAyjXLlyhoeHh5ErVy4jX758xpgxYwxvb2/DYrFY38t58+ZZXysiIsJ499137b53InI7jcCI5AABAQFUr16dgQMHMnPmTPbs2UNqaqrdx5w6dYr4+Hji4+PZvHkzvr6+9OnTB4C1a9fStWtXxo8fz/nz51m2bBkffPAB8+fPt/l827dvd/gwvaioKMqVK0fhwoWt10JDQ7l27Zp11CIqKoqwsLA0jwsNDWXXrl3pfo5bPfPMMzRq1Ihz585x9uxZZsyYYT3I7v3332fJkiWsWbOG48eP4+XlxZYtW6yPPXz4MBEREYwYMYL4+HjefPNNPv30U0qWLGl9P7t162aNDw4OZtu2bQ69LyKiFpJIjrF27VqaNWvGJ598QlhYGIULF+all14iMTHR7uOOHTtG06ZNeeWVV+jZsycAkydPZvDgwTRq1AgPDw+qVavGoEGDmDlzps3nuXDhAn5+fg7lfPny5dtOwC1UqJD1nr2Yu92/+TlulTt3bmJiYjh27BheXl6EhIRQrFgxAGbOnMnw4cOpWrUq3t7ejBkzxvp898LPz48LFy7c8+NFcioVMCI5REBAAGPHjmXr1q3ExcXxxRdfMH36dCZMmGDzMefOnePJJ5+kc+fOvPTSS9brBw8eZMqUKRQsWND6591337VOCL4Tf39/4uLiHMrZ19eXS5cupbl28eJF6z17MXe7f/Nz3GrWrFlYLBYef/xxSpcuzdChQ4mPjwfg+PHjPPDAA9ZYT09PAgMDHfq5bhYXF4e/v/89P14kp1IBI5IDeXt707ZtWxo3bszOnTvvGHP16lVatGhBWFgYH3zwQZp7xYsXZ9SoUVy6dMn658qVK+zbt8/ma9auXdvu/TsJCQnh6NGjnD9/3npt+/bt+Pj4UKlSJWvMrS2Y7du3U7NmzXQ/x63Kli3L9OnTOXbsGOvWrWPlypXWQq906dJER0dbY2/cuGGdMGyLvcm8v//+O3Xq1LH7eBG5nQoYkRzg4sWLjBo1ij179pCYmMiNGzdYvXo1a9eu5bHHHrstPiUlhQ4dOlC4cGG++OKL21YqDRkyhKlTp7J69WpSUlJISUlh7969ty1fvln79u35+eef01xLTU0lISHB2sZKSkoiISHBuhdNREQEVapUYfjw4Vy5coWYmBjeeOMN+vbtS548eQBzvsoXX3zBhg0bSEpK4pNPPuGvv/4iMjIy3c9xq1mzZnH8+HEMw8DX1xcvLy+8vLwA6NWrFx9++CF//vkniYmJjB079q4toOLFi3Pu3Lk0RRTApUuX2Lp1K23btrX7eBG5A1fPIhaRzBcfH2/07dvXqFSpkpE/f37Dz8/PeOihh4x3333XSE1NNQwj7Sqkf1YF5cmTJ81KpKZNm1qf88cffzTq1q1rFCpUyChUqJDx8MMPG0uXLrWZw/Xr143ixYsbu3btsl775zVv/TNz5kxrTHR0tNG8eXMjX758hr+/v/Hss88aCQkJaZ576tSpRmBgoJEnTx6jZs2axrp169LcT89z3Kxnz55GiRIlDB8fH6N48eLGwIEDjatXrxqGYRhJSUnGsGHDjKJFi95xFZJhGEb9+vWN1157zfp9cnKy0bFjR8Pf39/w8/Mz5s+fbxiGYUyZMsVo0aKFzTxExDaLYRiGC+snEclB5s+fz4IFC/jhhx9cnUqGevTRR2ncuDFjxoxJ92OuXr3KQw89xM8//0zlypUzLzmRbMrL1QmISM7RrVu3NEuIc7J8+fKlmUsjIo7RHBgRERFxO2ohiYiIiNvRCIyIiIi4HRUwIiIi4nZUwIiIiIjbUQEjIiIibkcFjIiIiLgdFTAiIiLidlTAiIiIiNtRASMiIiJuRwWMiIiIuJ3/A11KkHFqQCsaAAAAAElFTkSuQmCC\n"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "This is a good model and we can use it to predict other houses based on the sqft"
+      ],
+      "metadata": {
+        "id": "khrawx1kbaxB"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Predicting on new datapoint\n",
+        "if the house has a sqft of 1200, how much would it cost?"
+      ],
+      "metadata": {
+        "id": "RHdLsWenbCJH"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "x_i = 1.2\n",
+        "cost = w * x_i + b\n",
+        "print(f'a house with {x_i*100:.0f} sqft would cost ${cost*1000:.0f} dollars!')"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "w9l6Y7TNa_kz",
+        "outputId": "2c061785-0225-4a31-e73b-f76d6ecfd4db"
+      },
+      "execution_count": 14,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "a house with 120 sqft would cost $340000 dollars!\n"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/deeplearning.mplstyle
+++ b/deeplearning.mplstyle
@@ -1,0 +1,124 @@
+# see https://matplotlib.org/stable/tutorials/introductory/customizing.html
+lines.linewidth: 4
+lines.solid_capstyle: butt
+
+legend.fancybox: true
+
+# Verdana" for non-math text,
+# Cambria Math
+
+#Blue (Crayon-Aqua) 0096FF
+#Dark Red C00000
+#Orange (Apple Orange) FF9300
+#Black 000000
+#Magenta FF40FF
+#Purple 7030A0
+
+axes.prop_cycle: cycler('color', ['0096FF', 'FF9300', 'FF40FF', '7030A0', 'C00000'])
+#axes.facecolor: f0f0f0 # grey
+axes.facecolor: ffffff  # white
+axes.labelsize: large
+axes.axisbelow: true
+axes.grid: False
+axes.edgecolor: f0f0f0
+axes.linewidth: 3.0
+axes.titlesize: x-large
+
+patch.edgecolor: f0f0f0
+patch.linewidth: 0.5
+
+svg.fonttype: path
+
+grid.linestyle: -
+grid.linewidth: 1.0
+grid.color: cbcbcb
+
+xtick.major.size: 0
+xtick.minor.size: 0
+ytick.major.size: 0
+ytick.minor.size: 0
+
+savefig.edgecolor: f0f0f0
+savefig.facecolor: f0f0f0
+
+#figure.subplot.left: 0.08
+#figure.subplot.right: 0.95
+#figure.subplot.bottom: 0.07
+
+#figure.facecolor: f0f0f0  # grey
+figure.facecolor: ffffff  # white
+
+## ***************************************************************************
+## * FONT                                                                    *
+## ***************************************************************************
+## The font properties used by `text.Text`.
+## See https://matplotlib.org/api/font_manager_api.html for more information
+## on font properties.  The 6 font properties used for font matching are
+## given below with their default values.
+##
+## The font.family property can take either a concrete font name (not supported
+## when rendering text with usetex), or one of the following five generic
+## values:
+##     - 'serif' (e.g., Times),
+##     - 'sans-serif' (e.g., Helvetica),
+##     - 'cursive' (e.g., Zapf-Chancery),
+##     - 'fantasy' (e.g., Western), and
+##     - 'monospace' (e.g., Courier).
+## Each of these values has a corresponding default list of font names
+## (font.serif, etc.); the first available font in the list is used.  Note that
+## for font.serif, font.sans-serif, and font.monospace, the first element of
+## the list (a DejaVu font) will always be used because DejaVu is shipped with
+## Matplotlib and is thus guaranteed to be available; the other entries are
+## left as examples of other possible values.
+##
+## The font.style property has three values: normal (or roman), italic
+## or oblique.  The oblique style will be used for italic, if it is not
+## present.
+##
+## The font.variant property has two values: normal or small-caps.  For
+## TrueType fonts, which are scalable fonts, small-caps is equivalent
+## to using a font size of 'smaller', or about 83%% of the current font
+## size.
+##
+## The font.weight property has effectively 13 values: normal, bold,
+## bolder, lighter, 100, 200, 300, ..., 900.  Normal is the same as
+## 400, and bold is 700.  bolder and lighter are relative values with
+## respect to the current weight.
+##
+## The font.stretch property has 11 values: ultra-condensed,
+## extra-condensed, condensed, semi-condensed, normal, semi-expanded,
+## expanded, extra-expanded, ultra-expanded, wider, and narrower.  This
+## property is not currently implemented.
+##
+## The font.size property is the default font size for text, given in points.
+## 10 pt is the standard value.
+##
+## Note that font.size controls default text sizes.  To configure
+## special text sizes tick labels, axes, labels, title, etc., see the rc
+## settings for axes and ticks.  Special text sizes can be defined
+## relative to font.size, using the following values: xx-small, x-small,
+## small, medium, large, x-large, xx-large, larger, or smaller
+
+
+font.family:  sans-serif
+font.style:   normal
+font.variant: normal
+font.weight:  normal
+font.stretch: normal
+font.size:    8.0
+
+font.serif:      DejaVu Serif, Bitstream Vera Serif, Computer Modern Roman, New Century Schoolbook, Century Schoolbook L, Utopia, ITC Bookman, Bookman, Nimbus Roman No9 L, Times New Roman, Times, Palatino, Charter, serif
+font.sans-serif: Verdana, DejaVu Sans, Bitstream Vera Sans, Computer Modern Sans Serif, Lucida Grande, Geneva, Lucid, Arial, Helvetica, Avant Garde, sans-serif
+font.cursive:    Apple Chancery, Textile, Zapf Chancery, Sand, Script MT, Felipa, Comic Neue, Comic Sans MS, cursive
+font.fantasy:    Chicago, Charcoal, Impact, Western, Humor Sans, xkcd, fantasy
+font.monospace:  DejaVu Sans Mono, Bitstream Vera Sans Mono, Computer Modern Typewriter, Andale Mono, Nimbus Mono L, Courier New, Courier, Fixed, Terminal, monospace
+
+
+## ***************************************************************************
+## * TEXT                                                                    *
+## ***************************************************************************
+## The text properties used by `text.Text`.
+## See https://matplotlib.org/api/artist_api.html#module-matplotlib.text
+## for more information on text properties
+#text.color: black
+


### PR DESCRIPTION
This pull request adds the Linear Regression Representation notebook (01_Linear_Regression_Representation.ipynb) 
and the associated Matplotlib style file (deeplearning.mplstyle) to the repository.

Changes include:
- 01_linear_regression_representation.ipynb: Demonstrates linear regression concepts with visualizations.
- deeplearning.mplstyle: Custom style configuration for Matplotlib plots in the notebook.
